### PR TITLE
Allow specifying a source directory in configuration

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,6 +70,11 @@
           "default": "builddir",
           "description": "Specify in which folder Meson build configure and build the project."
         },
+        "mesonbuild.sourceFolder": {
+          "type": "string",
+          "default": "",
+          "description": "Specify in which folder (relative to the workspace root) the meson.build file is located."
+        },
         "mesonbuild.configureOptions": {
           "type": "array",
           "default": [

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -46,7 +46,7 @@ export function activate(ctx: vscode.ExtensionContext): void {
   ctx.subscriptions.push(
     vscode.commands.registerCommand("mesonbuild.configure", async () => {
       await runMesonConfigure(
-        root,
+        workspaceRelative(extensionConfiguration("sourceFolder")),
         workspaceRelative(extensionConfiguration("buildFolder"))
       );
       explorer.refresh();

--- a/src/meson/runners.ts
+++ b/src/meson/runners.ts
@@ -20,7 +20,7 @@ export async function runMesonConfigure(source: string, build: string) {
     async progress => {
       progress.report({
         message: `Checking if Meson is configured in ${relative(
-          source,
+          vscode.workspace.rootPath,
           build
         )}...`
       });
@@ -39,7 +39,7 @@ export async function runMesonConfigure(source: string, build: string) {
         await exec("ninja reconfigure", { cwd: build });
       } else {
         progress.report({
-          message: `Configuring Meson into ${relative(source, build)}...`
+          message: `Configuring Meson into ${relative(vscode.workspace.rootPath, build)}...`
         });
         const configureOpts = extensionConfiguration("configureOptions").join(
           " "

--- a/src/types.ts
+++ b/src/types.ts
@@ -4,4 +4,5 @@ export interface ExtensionConfiguration {
   configureOnOpen: boolean;
   configureOptions: string[];
   buildFolder: string;
+  sourceFolder: string;
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -109,11 +109,12 @@ export function workspaceRelative(filepath: string) {
 
 export async function getTargetName(t: Target) {
   const buildDir = workspaceRelative(extensionConfiguration("buildFolder"));
+  const sourceDir = workspaceRelative(extensionConfiguration("sourceFolder"));
   const buildOptions = await getMesonBuildOptions(buildDir);
   const layoutOption = buildOptions.filter(o => o.name === "layout")[0];
   if (layoutOption.value === "mirror")
     return path.join(
-      path.relative(vscode.workspace.rootPath, path.dirname(t.defined_in)),
+      path.relative(sourceDir, path.dirname(t.defined_in)),
       t.name
     );
   else return `meson-out/${t.name}`;


### PR DESCRIPTION
This allows the main meson.build file to be placed somewhere other than the root.