### PR TITLE
Add Debug command for languages that support GDB

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -8,8 +8,7 @@
       "request": "launch",
       "runtimeExecutable": "${execPath}",
       "args": [
-        "--extensionDevelopmentPath=${workspaceRoot}",
-        "--disable-extensions"
+        "--extensionDevelopmentPath=${workspaceRoot}"
       ]
       // "preLaunchTask": "compile"
     }

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "onCommand:mesonbuild.configure",
     "onCommand:mesonbuild.build",
     "onCommand:mesonbuild.test",
+    "onCommand:mesonbuild.debug",
     "workspaceContains:meson.build"
   ],
   "main": "./out/src/extension",
@@ -55,6 +56,10 @@
       {
         "command": "mesonbuild.test",
         "title": "Meson: Run Unit Tests"
+      },
+      {
+        "command": "mesonbuild.debug",
+        "title": "Meson: Debug"
       }
     ],
     "configuration": {

--- a/src/debugger.ts
+++ b/src/debugger.ts
@@ -1,0 +1,36 @@
+import * as path from "path";
+
+export type ExecutableTarget = {
+  path: string;
+  name: string;
+};
+
+export interface Configuration {
+  type: string;
+  name: string;
+  request: string;
+  program: string;
+  MIMode: string;
+  [key: string]: any;
+}
+
+export async function createDebugConfiguration(
+  target: ExecutableTarget
+): Promise<Configuration> {
+  return {
+    type: "cppdbg",
+    name: `Debug ${target.name}`,
+    request: "launch",
+    program: target.path,
+    cwd: path.dirname(target.path),
+    MIMode: "gdb",
+    args: [],
+    setupCommands: [
+      {
+        description: "Enable pretty-printing for gdb",
+        text: "-enable-pretty-printing",
+        ignoreFailures: true,
+      },
+    ],
+  };
+}


### PR DESCRIPTION
- Based on [cmake-tools](https://github.com/microsoft/vscode-cmake-tools) debug command
- Finds the first executable defined for build and launches it under the vscode debugger
- Requires [cpptools](https://github.com/microsoft/vscode-cpptools) extension for cppdbg support
- Tested C, C++, and Vala projects with it
- Accidentally ran prettier