### PR TITLE
Rework configure prompt

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,8 +61,18 @@
       "title": "Meson build configuration",
       "properties": {
         "mesonbuild.configureOnOpen": {
-          "type": "boolean",
-          "default": false,
+          "type": ["string", "boolean"],
+          "default": "ask",
+          "enum": [
+            "ask",
+            true,
+            false
+          ],
+          "enumDescriptions": [
+            "Ask every time",
+            "Always configure on open",
+            "Never configure on open"
+          ],
           "description": "Have VS Code run meson configure/ninja reconfigure on folder open."
         },
         "mesonbuild.buildFolder": {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -178,47 +178,44 @@ export function activate(ctx: vscode.ExtensionContext): void {
     })
   );
 
-  if (extensionConfiguration("configureOnOpen"))
+  var configureOnOpen = extensionConfiguration("configureOnOpen");
+  if (configureOnOpen === true)
     vscode.commands
       .executeCommand<boolean>("mesonbuild.configure")
       .then(isFresh => {
         explorer.refresh();
       });
-  else {
+  else if (configureOnOpen === "ask") {
     vscode.window
       .showInformationMessage(
         "Meson project detected, would you like VS Code to configure it?",
         "No",
-        "This workspace",
-        "Yes"
+        "Never",
+        "Yes",
+        "Always"
       )
       .then(response => {
         switch (response) {
-          case "Yes":
+          case "Never":
             extensionConfigurationSet(
               "configureOnOpen",
-              true,
-              vscode.ConfigurationTarget.Global
+              false,
+              vscode.ConfigurationTarget.Workspace
             );
+          case "No":
             break;
-          case "This workspace":
+
+          case "Always":
             extensionConfigurationSet(
               "configureOnOpen",
               true,
               vscode.ConfigurationTarget.Workspace
             );
+          case "Yes":
+            vscode.commands
+              .executeCommand("mesonbuild.configure")
+              .then(() => explorer.refresh());
             break;
-          default:
-            extensionConfigurationSet(
-              "configureOnOpen",
-              false,
-              vscode.ConfigurationTarget.Global
-            );
-        }
-        if (response !== "No") {
-          vscode.commands
-            .executeCommand("mesonbuild.configure")
-            .then(() => explorer.refresh());
         }
       });
   }

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,7 +1,7 @@
 import * as vscode from "vscode";
 
 export interface ExtensionConfiguration {
-  configureOnOpen: boolean;
+  configureOnOpen: string | boolean;
   configureOptions: string[];
   buildFolder: string;
 }


### PR DESCRIPTION
The configuration prompt is rather confusing and a bit annoying:

  * The dialog says "meson project detected", hinting that the dialog is only asking about this project, but "Yes" and "No" change global settings.

  * The difference between "Yes" and "This workspace" is unclear

  * If I hit "No", it continues to ask every time the project is opened, so it feels like "No" doesn't actually change anything.

The new prompt:

  * Only changes workspace settings

  * Includes "Always" and "Never" to make clear that "Yes" and "No" are one time operations

  * Allows the user to disable the prompt globally / per-workspace