### PR TITLE
Fix the issue where the "configure on open" question is asked again when `configureOnOpen` is set to `false`

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -140,17 +140,15 @@ export function activate(ctx: vscode.ExtensionContext): void {
               },
               ...tests.map<vscode.QuickPickItem>(t => ({
                 label: t.name,
-                detail: `Test timeout: ${t.timeout}s, ${
-                  t.is_parallel ? "Run in parallel" : "Run serially"
-                }`,
+                detail: `Test timeout: ${t.timeout}s, ${t.is_parallel ? "Run in parallel" : "Run serially"
+                  }`,
                 description: t.suite.join(","),
                 picked: false
               })),
               ...benchmarks.map<vscode.QuickPickItem>(b => ({
                 label: b.name,
-                detail: `Benchmark timeout: ${
-                  b.timeout
-                }s, benchmarks always run serially`,
+                detail: `Benchmark timeout: ${b.timeout
+                  }s, benchmarks always run serially`,
                 description: b.suite.join(","),
                 picked: false
               }))
@@ -184,7 +182,7 @@ export function activate(ctx: vscode.ExtensionContext): void {
       .then(isFresh => {
         explorer.refresh();
       });
-  else {
+  else if (!ctx.workspaceState.get<boolean>("askedWhetherToConfigureOnOpen")) {
     vscode.window
       .showInformationMessage(
         "Meson project detected, would you like VS Code to configure it?",
@@ -221,5 +219,7 @@ export function activate(ctx: vscode.ExtensionContext): void {
             .then(() => explorer.refresh());
         }
       });
+    ctx.workspaceState.update("askedWhetherToConfigureOnOpen", true);
   }
+}
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -182,7 +182,7 @@ export function activate(ctx: vscode.ExtensionContext): void {
       .then(isFresh => {
         explorer.refresh();
       });
-  else if (!ctx.workspaceState.get<boolean>("askedWhetherToConfigureOnOpen")) {
+  else if (!ctx.workspaceState.get<boolean>("answeredWhetherToConfigureOnOpen"))
     vscode.window
       .showInformationMessage(
         "Meson project detected, would you like VS Code to configure it?",
@@ -213,13 +213,12 @@ export function activate(ctx: vscode.ExtensionContext): void {
               vscode.ConfigurationTarget.Global
             );
         }
-        if (response !== undefined && response !== "No") {
-          vscode.commands
-            .executeCommand("mesonbuild.configure")
-            .then(() => explorer.refresh());
+        if (response !== undefined) {
+          if (response !== "No")
+            vscode.commands
+              .executeCommand("mesonbuild.configure")
+              .then(() => explorer.refresh());
+          ctx.workspaceState.update("answeredWhetherToConfigureOnOpen", true);
         }
       });
-    ctx.workspaceState.update("askedWhetherToConfigureOnOpen", true);
-  }
-}
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -213,7 +213,7 @@ export function activate(ctx: vscode.ExtensionContext): void {
               vscode.ConfigurationTarget.Global
             );
         }
-        if (response !== "No") {
+        if (response !== undefined && response !== "No") {
           vscode.commands
             .executeCommand("mesonbuild.configure")
             .then(() => explorer.refresh());


### PR DESCRIPTION
This fixes #35, albeit not exactly as specified.  Since the behavior of `configureOnOpen` is to automatically configure the project without asking the user anything and its default value is `false`, we have to ask the user the first time a workspace is opened with this extension enabled (otherwise the question would never be asked).  If the user answers something without dismissing the notification, we persist in the per-workspace extension state that the user has answered the question.  However, if they dismiss the notification, we treat this as a non-answer so that the user would be asked again when the open the workspace.