### PR TITLE
Update names to point to mesonbuild instead of asabil

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,21 +5,33 @@
   "icon": "graphics/icon.png",
   "version": "1.3.0",
   "license": "Apache-2.0",
-  "publisher": "asabil",
+  "publisher": "mesonbuild",
   "author": {
-    "name": "Ali Sabil"
+    "name": "The Meson Project"
   },
   "contributors": [
-    "Nathan Graule <solarliner@gmail.com> (https://solarliner.me)"
+    {
+      "name": "Ali Sabil"
+    },
+    {
+      "name": "Nathan Graule",
+      "email": "solarliner@gmail.com",
+      "url": "https://solarliner.me"
+    },
+    {
+      "name": "Dylan Baker",
+      "email": "dylan@pnwbakers.com",
+      "url": "https://recursiveascent.blogspot.com/"
+    }
   ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/asabil/vscode-meson.git"
+    "url": "https://github.com/mesonbuild/vscode-meson.git"
   },
   "bugs": {
-    "url": "https://github.com/asabil/vscode-meson/issues"
+    "url": "https://github.com/mesonbuild/vscode-meson/issues"
   },
-  "homepage": "https://github.com/asabil/vscode-meson/blob/master/README.md",
+  "homepage": "https://github.com/mesonbuild/vscode-meson/blob/master/README.md",
   "engines": {
     "vscode": "^1.26.0"
   },

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -94,7 +94,7 @@ export function getOutputChannel(): vscode.OutputChannel {
 }
 
 export function thisExtension() {
-  const ext = vscode.extensions.getExtension("asabil.meson");
+  const ext = vscode.extensions.getExtension("mesonbuild.meson");
   if (ext) return ext;
   else throw new Error("Extension not found");
 }


### PR DESCRIPTION
Since the package has moved into the meson project namespace. I've made
the "author" name the meson project, and added contributors for the the
other entries.