### PR TITLE
Fix when tests and benchmarks have the same name

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "onCommand:mesonbuild.configure",
     "onCommand:mesonbuild.build",
     "onCommand:mesonbuild.test",
+    "onCommand:mesonbuild.benchmark",
     "workspaceContains:meson.build"
   ],
   "main": "./out/src/extension",
@@ -67,6 +68,10 @@
       {
         "command": "mesonbuild.test",
         "title": "Meson: Run Unit Tests"
+      },
+      {
+        "command": "mesonbuild.benchmark",
+        "title": "Meson: Run Benchmarks"
       }
     ],
     "configuration": {

--- a/src/meson/runners.ts
+++ b/src/meson/runners.ts
@@ -117,17 +117,18 @@ export async function runMesonBuild(buildDir: string, name?: string) {
   );
 }
 
-export async function runMesonTests(build: string, name?: string) {
+export async function runMesonTests(buildDir: string, isBenchmark: boolean, name?: string) {
   try {
-    const args = ["test"].concat(name ?? []);
+    const benchmarkArgs = isBenchmark ? ["--benchmark", "--verbose"] : [];
+    const args = ["test", ...benchmarkArgs].concat(name ?? []);
     return await execAsTask(
       "meson", args,
-      { cwd: build },
+      { cwd: buildDir },
       vscode.TaskRevealKind.Always
     );
   } catch (e) {
     if (e.stderr) {
-      vscode.window.showErrorMessage("Tests failed.");
+      vscode.window.showErrorMessage(`${isBenchmark ? "Benchmarks" : "Tests"} failed.`);
     }
   }
 }

--- a/src/tasks.ts
+++ b/src/tasks.ts
@@ -40,7 +40,7 @@ export async function getMesonTasks(buildDir: string): Promise<vscode.Task[]> {
       { type: "meson", mode: "benchmark" },
       "Run benchmarks",
       "Meson",
-      new vscode.ProcessExecution("meson", ["test", "--benchmark"], { cwd: buildDir })
+      new vscode.ProcessExecution("meson", ["test", "--benchmark", "--verbose"], { cwd: buildDir })
     );
     const defaultReconfigureTask = new vscode.Task(
       { type: "meson", mode: "reconfigure" },
@@ -138,7 +138,7 @@ export async function getMesonTasks(buildDir: string): Promise<vscode.Task[]> {
           { type: "meson", mode: "benchmark", target: b.name },
           `Benchmark ${b.name}`,
           "Meson",
-          new vscode.ProcessExecution("meson", ["test", "--benchmark", b.name], {
+          new vscode.ProcessExecution("meson", ["test", "--benchmark", "--verbose", b.name], {
             env: b.env,
             cwd: buildDir
           })

--- a/src/treeview/nodes/tests.ts
+++ b/src/treeview/nodes/tests.ts
@@ -5,8 +5,8 @@ import { Test } from "../../meson/types";
 import { extensionRelative } from "../../utils";
 
 export class TestNode extends BaseNode {
-  constructor(private readonly test: Test) {
-    super(test.name);
+  constructor(private readonly test: Test, private readonly isBenchmark) {
+    super(`${isBenchmark ? "benchmark-" : "test-"}${test.name}`);
   }
 
   getChildren() {
@@ -18,8 +18,8 @@ export class TestNode extends BaseNode {
     item.label = this.test.name;
     item.iconPath = extensionRelative("res/meson_32.svg");
     item.command = {
-      title: "Run test",
-      command: "mesonbuild.test",
+      title: `Run ${this.isBenchmark ? "benchmark" : "test"}`,
+      command: `mesonbuild.${this.isBenchmark ? "benchmark" : "test"}`,
       arguments: [this.test.name]
     };
 

--- a/src/treeview/nodes/toplevel.ts
+++ b/src/treeview/nodes/toplevel.ts
@@ -57,24 +57,6 @@ export class SubprojectsRootNode extends BaseNode {
   }
 }
 
-export class TargetsRootNode extends BaseNode {
-  constructor(private readonly targets: Targets) {
-    super(hash(targets.map(t => `${t.subproject}/${t.name}`).join(";")));
-  }
-
-  getTreeItem() {
-    const item = super.getTreeItem() as vscode.TreeItem;
-    item.label = "Targets";
-    item.iconPath = extensionRelative("res/meson_32.svg");
-    item.collapsibleState = vscode.TreeItemCollapsibleState.Collapsed;
-    return item;
-  }
-
-  getChildren() {
-    return this.targets.map(t => new TargetNode(t));
-  }
-}
-
 export class TestRootNode extends BaseNode {
   constructor(private readonly tests: Tests, private readonly isBenchmark) {
     super(hash(tests.map(t => t.suite + t.name).join(";") + `${isBenchmark ? "-benchmarks" : "-tests"}`));
@@ -109,8 +91,8 @@ export class SubprojectNode extends BaseNode {
   }
 
   async getChildren() {
-    return await getMesonTargets(this.buildDir)
-      .then(tts => tts.filter(t => t.subproject === this.subproject.name))
-      .then(tt => tt.map(t => new TargetNode(t)));
+    const targets = await getMesonTargets(this.buildDir);
+
+    return targets.filter(t => t.subproject === this.subproject.name).map(t => new TargetNode(t));
   }
 }


### PR DESCRIPTION
Meson itself doesn't seem to mind tests and benchmarks having the same name. The extension doesn't allow it, though (or rather just fails to add benchmark nodes to the tree view due to duplicate node id).

Here's a fix and it also separates out benchmarks in to a new top level node, which I think looks nicer.

It also uses `--verbose` for running benchmarks as the output is generally of interest. But maybe that should be a config option?

And a few other tidy ups.

Cheers
