### PR TITLE
fix: wrong command name used by MesonProjectExplorer.refresh().

### DIFF
--- a/src/treeview/index.ts
+++ b/src/treeview/index.ts
@@ -3,14 +3,15 @@ import { BaseNode } from "./basenode";
 import { getMesonProjectInfo } from "../meson/introspection";
 import { ProjectNode } from "./nodes/toplevel";
 
-export class MesonProjectDataProvider
-  implements vscode.TreeDataProvider<BaseNode> {
-  private _onDataChangeEmitter = new vscode.EventEmitter<BaseNode>();
+class MesonProjectDataProvider implements vscode.TreeDataProvider<BaseNode> {
+  private readonly _onDataChangeEmitter = new vscode.EventEmitter<BaseNode>();
   readonly onDidChangeTreeData = this._onDataChangeEmitter.event;
 
-  constructor(ctx: vscode.ExtensionContext, private buildDir: string) {
+  static readonly commandName = "mesonbuild.view-refresh";
+
+  constructor(ctx: vscode.ExtensionContext, private readonly buildDir: string) {
     ctx.subscriptions.push(
-      vscode.commands.registerCommand("mesonbuild.view-refresh", () =>
+      vscode.commands.registerCommand(MesonProjectDataProvider.commandName, () =>
         this.refresh()
       )
     );
@@ -23,18 +24,19 @@ export class MesonProjectDataProvider
   getTreeItem(element: BaseNode) {
     return element.getTreeItem();
   }
+
   async getChildren(element?: BaseNode) {
-    if (element) return element.getChildren();
-    return [
-      await getMesonProjectInfo(this.buildDir).then(
-        p => new ProjectNode(p, this.buildDir)
-      )
-    ];
+    if (element) {
+      return element.getChildren();
+    }
+
+    const projectInfo = await getMesonProjectInfo(this.buildDir);
+    return [new ProjectNode(projectInfo, this.buildDir)];
   }
 }
 
 export class MesonProjectExplorer {
-  private viewer: vscode.TreeView<BaseNode>;
+  private readonly viewer: vscode.TreeView<BaseNode>;
 
   constructor(ctx: vscode.ExtensionContext, buildDir: string) {
     const treeDataProvider = new MesonProjectDataProvider(ctx, buildDir);
@@ -44,6 +46,6 @@ export class MesonProjectExplorer {
   }
 
   public refresh() {
-    vscode.commands.executeCommand("mesonbuild.targets-refresh");
+    vscode.commands.executeCommand(MesonProjectDataProvider.commandName);
   }
 }


### PR DESCRIPTION
Broken in b24c9a23, by the looks of it.

```
stack trace: Error: command 'mesonbuild.targets-refresh' not found
    at h._tryExecuteCommand (vscode-file://vscode-app/usr/share/code/resources/app/out/vs/workbench/workbench.desktop.main.js:1501:3364)
    at vscode-file://vscode-app/usr/share/code/resources/app/out/vs/workbench/workbench.desktop.main.js:1501:3245
    at processTicksAndRejections (internal/process/task_queues.js:93:5)
```