### PR TITLE
Refactor configure prompt

### DIFF
--- a/package.json
+++ b/package.json
@@ -88,7 +88,12 @@
             false,
             "ask"
           ],
-          "description": "Have VS Code run meson (re)configure on folder open."
+          "enumDescriptions": [
+            "Always configure on open",
+            "Never configure on open",
+            "Ask every time"
+          ],
+          "description": "Have VS Code run Meson (re)configure on opening a folder."
         },
         "mesonbuild.buildFolder": {
           "type": "string",


### PR DESCRIPTION
Here's an update of #31 so it applies cleanly and some tidy ups.

BTW there's still some issues with the prompt in that if you open a workspace that has no meson.build and accidentally hit F1 -> Meson -> Build the extension is activated so it pops up (and then the pick target prompt just sits there). Lots of activation events other than `meson.build`...

```
  "activationEvents": [
    "onLanguage:meson",
    "onCommand:mesonbuild.configure",
    "onCommand:mesonbuild.build",
    "onCommand:mesonbuild.test",
    "onCommand:mesonbuild.benchmark",
    "workspaceContains:meson.build"
  ],
```

