### PR TITLE
Change setting mesonbuild.configureOnOpen

### DIFF
--- a/package.json
+++ b/package.json
@@ -78,8 +78,16 @@
       "title": "Meson build configuration",
       "properties": {
         "mesonbuild.configureOnOpen": {
-          "type": "boolean",
-          "default": false,
+          "type": [
+            "boolean",
+            "string"
+          ],
+          "default": "ask",
+          "enum": [
+            true,
+            false,
+            "ask"
+          ],
           "description": "Have VS Code run meson (re)configure on folder open."
         },
         "mesonbuild.buildFolder": {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -97,49 +97,51 @@ export function activate(ctx: vscode.ExtensionContext): void {
     })
   );
 
-  if (extensionConfiguration("configureOnOpen"))
-    vscode.commands
-      .executeCommand<boolean>("mesonbuild.configure")
-      .then(isFresh => {
-        explorer.refresh();
-      });
-  else {
-    vscode.window
-      .showInformationMessage(
-        "Meson project detected, would you like VS Code to configure it?",
-        "No",
-        "This workspace",
-        "Yes"
-      )
-      .then(response => {
-        switch (response) {
-          case "Yes":
-            extensionConfigurationSet(
-              "configureOnOpen",
-              true,
-              vscode.ConfigurationTarget.Global
-            );
-            break;
-          case "This workspace":
-            extensionConfigurationSet(
-              "configureOnOpen",
-              true,
-              vscode.ConfigurationTarget.Workspace
-            );
-            break;
-          default:
-            extensionConfigurationSet(
-              "configureOnOpen",
-              false,
-              vscode.ConfigurationTarget.Global
-            );
-        }
-        if (response !== "No") {
-          vscode.commands
-            .executeCommand("mesonbuild.configure")
-            .then(() => explorer.refresh());
-        }
-      });
+  switch (extensionConfiguration("configureOnOpen")) {
+    case false: {
+      break;
+    }
+    case true: {
+      vscode.commands
+        .executeCommand<boolean>("mesonbuild.configure")
+        .then((isFresh) => {
+          explorer.refresh();
+        });
+      break;
+    }
+    case "ask":
+    default: {
+      vscode.window
+        .showInformationMessage(
+          "Meson project detected, would you like VS Code to configure it?",
+          "Yes",
+          "No"
+        )
+        .then((response) => {
+          switch (response) {
+            case "Yes":
+              extensionConfigurationSet(
+                "configureOnOpen",
+                true,
+                vscode.ConfigurationTarget.Workspace
+              );
+              vscode.commands
+                .executeCommand("mesonbuild.configure")
+                .then(() => explorer.refresh());
+              break;
+            case "No":
+              extensionConfigurationSet(
+                "configureOnOpen",
+                false,
+                vscode.ConfigurationTarget.Workspace
+              );
+              break;
+            default:
+              break;
+          }
+        });
+      break;
+    }
   }
 
   async function pickBuildTarget() {

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,7 +1,7 @@
 import * as vscode from "vscode";
 
 export interface ExtensionConfiguration {
-  configureOnOpen: boolean;
+  configureOnOpen: boolean | "ask";
   configureOptions: string[];
   buildFolder: string;
 }


### PR DESCRIPTION
This commit separates the global `settings.json` and workspace `settings.json` values for `mesonbuild.configureOnOpen`. The setting now takes one of the values of `true`(bool), `false`(bool), `"ask"`(string)(default).

The previous behaviour of `false` made the extension ask the user every time they opened a workspace whether to configure or not, which was annoying. This has been changed: `false` now does not ask the user; `"ask"` will ask the user each time. `true` or `false` will run the configure task or not. This makes it easy for the user to set `mesonbuild.configureOnOpen` to `true` or `false` in their global `settings.json`, and/or have it set differently for individual projects in the workspace's `settings.json`.

The "Meson project detected" popup message for whether to configure, and set `settings.json` has been changed: Answering `"Yes"` or `"No"` will set the value of `mesonbuild.configureOnOpen` to `true` or `false` respectively in the workspace's `settings.json` (there is now no need for a `"This workspace"` option, and any answer to the popup will not affect the global `settings.json` value). Also clicking the `x` to dismiss the popup is no longer interpreted as "Yes"; dismissing does nothing as it should (this was one of the most annoying parts that needed fixing).

This commit / PR supercedes #36