### PR TITLE
Integrate with the native testing API (including debug)

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -9,7 +9,6 @@ import {
 import { getMesonTasks } from "./tasks";
 import { MesonProjectExplorer } from "./treeview";
 import {
-  exec,
   extensionConfiguration,
   execAsTask,
   workspaceRelative,
@@ -22,9 +21,6 @@ import {
   getMesonBenchmarks
 } from "./meson/introspection";
 import {DebugConfigurationProvider} from "./configprovider";
-import {
-  Tests,
-} from "./meson/types";
 import {
   testDebugHandler,
   testRunHandler,

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -76,7 +76,7 @@ export async function activate(ctx: vscode.ExtensionContext) {
   controller.createRunProfile("Meson debug test", vscode.TestRunProfileKind.Debug, (request, token) => testDebugHandler(controller, request, token), true)
   controller.createRunProfile("Meson run test", vscode.TestRunProfileKind.Run, (request, token) => testRunHandler(controller, request, token), true)
 
-  let changeHandler = async () => { explorer.refresh(), await rebuildTests(controller);};
+  let changeHandler = async () => { explorer.refresh(); await rebuildTests(controller);};
 
   watcher.onDidChange(changeHandler);
   watcher.onDidCreate(changeHandler);

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -27,7 +27,8 @@ import {
 } from "./meson/types";
 import {
   testDebugHandler,
-  testRunHandler
+  testRunHandler,
+  rebuildTests
 } from "./tests";
 
 
@@ -75,22 +76,7 @@ export async function activate(ctx: vscode.ExtensionContext) {
   controller.createRunProfile("Meson debug test", vscode.TestRunProfileKind.Debug, (request, token) => testDebugHandler(controller, request, token), true)
   controller.createRunProfile("Meson run test", vscode.TestRunProfileKind.Run, (request, token) => testRunHandler(controller, request, token), true)
 
-  let changeHandler = async () =>  {
-    explorer.refresh();
-    
-    let tests = await getMesonTests(workspaceRelative(extensionConfiguration("buildFolder")))
-
-    controller.items.forEach(item => {
-      if (!tests.some(test => item.id == test.name)) {
-        controller.items.delete(item.id);
-      }
-    });
-
-    for (let testDescr of tests) {
-      let testItem = controller.createTestItem(testDescr.name, testDescr.name)
-      controller.items.add(testItem)
-    }
-  };
+  let changeHandler = async () => { explorer.refresh(), await rebuildTests(controller);};
 
   watcher.onDidChange(changeHandler);
   watcher.onDidCreate(changeHandler);

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -79,8 +79,15 @@ export async function activate(ctx: vscode.ExtensionContext) {
     explorer.refresh();
     
     let tests = await getMesonTests(workspaceRelative(extensionConfiguration("buildFolder")))
-    for (let testDescr in tests) {
-      let testItem = controller.createTestItem(testDescr, testDescr)
+
+    controller.items.forEach(item => {
+      if (!tests.some(test => item.id == test.name)) {
+        controller.items.delete(item.id);
+      }
+    });
+
+    for (let testDescr of tests) {
+      let testItem = controller.createTestItem(testDescr.name, testDescr.name)
       controller.items.add(testItem)
     }
   };

--- a/src/meson/introspection.ts
+++ b/src/meson/introspection.ts
@@ -1,4 +1,3 @@
-import * as vscode from "vscode";
 import * as path from "path";
 import { exec, parseJSONFileIfExists } from "../utils";
 import {
@@ -8,7 +7,6 @@ import {
   Tests,
   ProjectInfo
 } from "./types";
-import * as fs from "fs";
 
 async function introspectMeson<T>(buildDir: string, filename: string, introspectSwitch: string) {
   const parsed = await parseJSONFileIfExists<T>(

--- a/src/meson/introspection.ts
+++ b/src/meson/introspection.ts
@@ -6,8 +6,6 @@ import {
   Dependencies,
   BuildOptions,
   Tests,
-  TestLog,
-  TestLogs,
   ProjectInfo
 } from "./types";
 import * as fs from "fs";
@@ -54,25 +52,6 @@ export async function getMesonDependencies(buildDir: string) {
 
 export async function getMesonTests(buildDir: string) {
   return introspectMeson<Tests>(buildDir, "intro-tests.json", "--tests");
-}
-
-export async function getMesonTestLogs(buildDir: string) : Promise<TestLogs> {
-  /* We have to hand-roll things a bit here, since meson doesn't expose this. */
-  let filename = path.join(buildDir, path.join("meson-logs", "testlog.json"));
-
-  try {
-    const data = await fs.promises.readFile(filename);
-    /* The handrolling gets annoying here. Because the file is not valid json.
-     * It's a concatenation of json objects, without a list wrapper.
-     * Luckily, the only newlines in the file are between the objects.
-     * The filter gets rid of an empty line at the end that breaks the json parser */
-    return data.toString().split("\n").filter(x => x).map(v => JSON.parse(v) as TestLog)
-  }
-  catch (err) {
-    vscode.window.showErrorMessage("Failed to read test log. Results will not be updated")
-    console.log(err);
-    return [];
-  }
 }
 
 export async function getMesonBenchmarks(buildDir: string) {

--- a/src/meson/introspection.ts
+++ b/src/meson/introspection.ts
@@ -5,8 +5,11 @@ import {
   Dependencies,
   BuildOptions,
   Tests,
+  TestLog,
+  TestLogs,
   ProjectInfo
 } from "./types";
+import * as fs from "fs";
 
 async function introspectMeson<T>(buildDir: string, filename: string, introspectSwitch: string) {
   const parsed = await parseJSONFileIfExists<T>(
@@ -50,6 +53,19 @@ export async function getMesonDependencies(buildDir: string) {
 
 export async function getMesonTests(buildDir: string) {
   return introspectMeson<Tests>(buildDir, "intro-tests.json", "--tests");
+}
+
+export async function getMesonTestLogs(buildDir: string) : Promise<TestLogs> {
+  let filename = path.join(buildDir, path.join("meson-logs", "testlog.json"));
+
+  try {
+    const data = await fs.promises.readFile(filename);
+    return data.toString().split("\n").filter(x => x).map(v => JSON.parse(v) as TestLog)
+  }
+  catch (err) {
+    console.log(err);
+    return [];
+  }
 }
 
 export async function getMesonBenchmarks(buildDir: string) {

--- a/src/meson/types.ts
+++ b/src/meson/types.ts
@@ -79,7 +79,20 @@ export interface Test {
   env: Dict<string>;
 }
 
+export interface TestLog {
+  name: string;
+  stdout: string;
+  result: string;
+  stattime: number;
+  duration: number;
+  returncode: number;
+  env: any;
+  command: string[];
+  stderr: string | null;
+}
+
 export type Targets = Target[];
 export type BuildOptions = BuildOption<any>[];
 export type Dependencies = Dependency[];
 export type Tests = Test[];
+export type TestLogs = TestLog[];

--- a/src/meson/types.ts
+++ b/src/meson/types.ts
@@ -77,6 +77,7 @@ export interface Test {
   is_parallel: boolean;
   cmd: string[];
   env: Dict<string>;
+  depends: string[];
 }
 
 export interface TestLog {

--- a/src/meson/types.ts
+++ b/src/meson/types.ts
@@ -80,20 +80,7 @@ export interface Test {
   depends: string[];
 }
 
-export interface TestLog {
-  name: string;
-  stdout: string;
-  result: string;
-  stattime: number;
-  duration: number;
-  returncode: number;
-  env: any;
-  command: string[];
-  stderr: string | null;
-}
-
 export type Targets = Target[];
 export type BuildOptions = BuildOption<any>[];
 export type Dependencies = Dependency[];
 export type Tests = Test[];
-export type TestLogs = TestLog[];

--- a/src/tests.ts
+++ b/src/tests.ts
@@ -10,7 +10,8 @@ import {
 } from "./meson/types"
 import {
     getMesonTests,
-    getMesonTestLogs
+    getMesonTestLogs,
+    getMesonTargets
 } from "./meson/introspection"
 
 export async function rebuildTests(controller: vscode.TestController) {
@@ -48,6 +49,8 @@ export async function testRunHandler(controller: vscode.TestController, request:
         await exec('meson', args);
     } catch(e) {
         if (e.error.code == 125) {
+            /* If desired, we could probably do this in a way that we fault every test in this error case.
+             * Might be better semantically but at the same time, those tests didn't fail. */
             vscode.window.showErrorMessage("Failed to build tests. Results will not be updated");
         }
         run.appendOutput(e.stdout);
@@ -84,22 +87,40 @@ export async function testDebugHandler(controller: vscode.TestController, reques
     }
 
     const tests: Tests = await getMesonTests(workspaceRelative(extensionConfiguration("buildFolder")));
-    for (let test of queue) {
-        for (let config of tests) {
-        if (test.id == config.name) {
-            let args = [...config.cmd]
-            args.shift();
-            await vscode.debug.startDebugging(undefined, {
-                    name: `meson-debug-${test.id}`,
-                    type: "cppdbg",
-                    request: "launch",
-                    cwd: config.workdir || workspaceRelative(extensionConfiguration("buildFolder")),
-                    env: config.env,
-                    program: config.cmd[0],
-                    args: args,
-                });
-            }
-        }
+    const targets = await getMesonTargets(workspaceRelative(extensionConfiguration("buildFolder")));
+
+    /* while meson has the --gdb arg to test, but IMO we should go the actual debugger route.
+     * We still want stuff to be built though... Without going through weird dances */
+    const relevantTests = tests.filter(test => queue.some(candidate => candidate.id == test.name));
+    const requiredTargets = targets.filter(target => relevantTests.some(test => test.depends.some(dep => dep == target.id)));
+
+    var args = ['compile', '-C', workspaceRelative(extensionConfiguration("buildFolder"))]
+    requiredTargets.forEach(target => {
+        args.push(target.name);
+    });
+
+    try {
+        await exec('meson', args);
+    } catch(e) {
+        vscode.window.showErrorMessage("Failed to build tests. Results will not be updated");
+        run.end();
+        return;
+    }
+
+    /* We already figured out which tests we want to run.
+     * We don't use the actual test either way, as we don't get the result here... */
+    for (let test of relevantTests) {
+        let args = [...test.cmd]
+        args.shift();
+        await vscode.debug.startDebugging(undefined, {
+                name: `meson-debug-${test.name}`,
+                type: "cppdbg",
+                request: "launch",
+                cwd: test.workdir || workspaceRelative(extensionConfiguration("buildFolder")),
+                env: test.env,
+                program: test.cmd[0],
+                args: args,
+            });
     }
 
     run.end();

--- a/src/tests.ts
+++ b/src/tests.ts
@@ -1,0 +1,82 @@
+import * as vscode from "vscode";
+import {
+  exec,
+  extensionConfiguration,
+  workspaceRelative,
+} from "./utils";
+import {
+    Tests,
+    TestLogs
+} from "./meson/types"
+import {
+    getMesonTests,
+    getMesonTestLogs
+} from "./meson/introspection"
+
+export async function testRunHandler(controller: vscode.TestController, request: vscode.TestRunRequest, token: vscode.CancellationToken) {
+    const run = controller.createTestRun(request, null, false);
+    const queue: vscode.TestItem[] = [];
+
+    if (request.include) {
+        request.include.forEach(test => queue.push(test));
+    } else {
+        controller.items.forEach(test => queue.push(test));
+    }
+
+    queue.forEach(run.started);
+    var args = ['test', '-C', workspaceRelative(extensionConfiguration("buildFolder"))]
+    queue.forEach(test => {
+        args.push(test.id);
+    });
+
+    try {
+        await exec('meson', args)
+    } catch(e) {} finally {
+        const logs: TestLogs = await getMesonTestLogs(workspaceRelative(extensionConfiguration("buildFolder")));
+        logs.forEach(log => {
+        let split = log.name.split(' ').pop();
+        for (let test of queue) {
+            if (test.id == split) {
+            if (log.result == "OK") {
+                run.passed(test, log.duration * 1000);
+            } else {
+                run.failed(test, new vscode.TestMessage(log.stderr), log.duration);
+            }
+            }
+        }
+        });
+        run.end();
+    }
+}
+
+export async function testDebugHandler(controller: vscode.TestController, request: vscode.TestRunRequest, token: vscode.CancellationToken) {
+    const run = controller.createTestRun(request, null, false);
+    const queue: vscode.TestItem[] = [];
+
+    if (request.include) {
+        request.include.forEach(test => queue.push(test));
+    } else {
+        controller.items.forEach(test => queue.push(test));
+    }
+
+    const tests: Tests = await getMesonTests(workspaceRelative(extensionConfiguration("buildFolder")));
+    for (let test of queue) {
+        for (let config of tests) {
+        if (test.id == config.name) {
+            let args = [...config.cmd]
+            args.shift();
+            await vscode.debug.startDebugging(undefined, {
+            name: `meson-debug-${test.id}`,
+            type: "cppdbg",
+            request: "launch",
+            cwd: config.workdir || workspaceRelative(extensionConfiguration("buildFolder")),
+            env: config.env,
+            program: config.cmd[0],
+            args: args,
+            });
+        }
+        }
+    }
+
+    run.end();
+}

--- a/src/tests.ts
+++ b/src/tests.ts
@@ -38,27 +38,36 @@ export async function testRunHandler(controller: vscode.TestController, request:
         controller.items.forEach(test => queue.push(test));
     }
 
-    var args = ['test', '-C', workspaceRelative(extensionConfiguration("buildFolder"))]
+    var args = ['test', '-C', workspaceRelative(extensionConfiguration("buildFolder")), '--print-errorlog']
     queue.forEach(test => {
         run.started(test);
         args.push(test.id);
     });
 
     try {
-        await exec('meson', args)
-    } catch(e) {} finally {
+        await exec('meson', args);
+    } catch(e) {
+        if (e.error.code == 125) {
+            vscode.window.showErrorMessage("Failed to build tests. Results will not be updated");
+        }
+        run.appendOutput(e.stdout);
+    } finally {
         const logs: TestLogs = await getMesonTestLogs(workspaceRelative(extensionConfiguration("buildFolder")));
         logs.forEach(log => {
-        let split = log.name.split(' ').pop();
-        for (let test of queue) {
-            if (test.id == split) {
-                if (log.result == "OK") {
-                    run.passed(test, log.duration * 1000);
-                } else {
-                    run.failed(test, new vscode.TestMessage(log.stderr), log.duration);
+            /* Not a fan of this, but the testlog output doesn't contain the actual input name.
+             * What it does contain is a mix of suite and name :/ */
+            /* If this ever becoes a real problem, we could match on command? I don't think we can do env... */
+            /* or we get the meson test tool to write the name proper as well, and if it's there match on that */
+            let split = log.name.split(' ').pop();
+            for (let test of queue) {
+                if (test.id == split) {
+                    if (log.result == "OK") {
+                        run.passed(test, log.duration * 1000);
+                    } else {
+                        run.failed(test, new vscode.TestMessage(log.stderr), log.duration);
+                    }
                 }
             }
-        }
         });
         run.end();
     }

--- a/src/tests.ts
+++ b/src/tests.ts
@@ -5,12 +5,10 @@ import {
   workspaceRelative,
 } from "./utils";
 import {
-    Tests,
-    TestLogs
+    Tests
 } from "./meson/types"
 import {
     getMesonTests,
-    getMesonTestLogs,
     getMesonTargets
 } from "./meson/introspection"
 

--- a/src/tests.ts
+++ b/src/tests.ts
@@ -37,11 +37,11 @@ export async function testRunHandler(controller: vscode.TestController, request:
         let split = log.name.split(' ').pop();
         for (let test of queue) {
             if (test.id == split) {
-            if (log.result == "OK") {
-                run.passed(test, log.duration * 1000);
-            } else {
-                run.failed(test, new vscode.TestMessage(log.stderr), log.duration);
-            }
+                if (log.result == "OK") {
+                    run.passed(test, log.duration * 1000);
+                } else {
+                    run.failed(test, new vscode.TestMessage(log.stderr), log.duration);
+                }
             }
         }
         });
@@ -66,15 +66,15 @@ export async function testDebugHandler(controller: vscode.TestController, reques
             let args = [...config.cmd]
             args.shift();
             await vscode.debug.startDebugging(undefined, {
-            name: `meson-debug-${test.id}`,
-            type: "cppdbg",
-            request: "launch",
-            cwd: config.workdir || workspaceRelative(extensionConfiguration("buildFolder")),
-            env: config.env,
-            program: config.cmd[0],
-            args: args,
-            });
-        }
+                    name: `meson-debug-${test.id}`,
+                    type: "cppdbg",
+                    request: "launch",
+                    cwd: config.workdir || workspaceRelative(extensionConfiguration("buildFolder")),
+                    env: config.env,
+                    program: config.cmd[0],
+                    args: args,
+                });
+            }
         }
     }
 

--- a/src/tests.ts
+++ b/src/tests.ts
@@ -13,6 +13,21 @@ import {
     getMesonTestLogs
 } from "./meson/introspection"
 
+export async function rebuildTests(controller: vscode.TestController) {
+    let tests = await getMesonTests(workspaceRelative(extensionConfiguration("buildFolder")))
+
+    controller.items.forEach(item => {
+      if (!tests.some(test => item.id == test.name)) {
+        controller.items.delete(item.id);
+      }
+    });
+
+    for (let testDescr of tests) {
+      let testItem = controller.createTestItem(testDescr.name, testDescr.name)
+      controller.items.add(testItem)
+    }
+  }
+
 export async function testRunHandler(controller: vscode.TestController, request: vscode.TestRunRequest, token: vscode.CancellationToken) {
     const run = controller.createTestRun(request, null, false);
     const queue: vscode.TestItem[] = [];

--- a/src/tests.ts
+++ b/src/tests.ts
@@ -23,9 +23,9 @@ export async function testRunHandler(controller: vscode.TestController, request:
         controller.items.forEach(test => queue.push(test));
     }
 
-    queue.forEach(run.started);
     var args = ['test', '-C', workspaceRelative(extensionConfiguration("buildFolder"))]
     queue.forEach(test => {
+        run.started(test);
         args.push(test.id);
     });
 


### PR DESCRIPTION
While the code in this works fine, I think there's a couple of things that I'd want some feedback on first.

Mainly:
* Debug runner:
  * should we try harder to pipe the result back into tests?
  * should we try to prevent debugging non-c(++) targets? This would require some heuristics (on dependencies) I think. 
* Testing runner:
  * should we run tests in series to avoid the testlog issue?
  * If not, should we fail the tests that couldn't be run? Maybe set all to skipped, that's a state vscode supports

Other than that, just general review :) 

Commits are messy, but this grew while learning^^

closes #23 