### PR TITLE
refactor: updated some deprecated vscode stuff.

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -28,11 +28,11 @@ let watcher: vscode.FileSystemWatcher;
 export async function activate(ctx: vscode.ExtensionContext) {
   extensionPath = ctx.extensionPath;
 
-  const root = vscode.workspace.rootPath;
-  if (!root) {
-    return
-  };
+  if (!vscode.workspace.workspaceFolders) {
+    return;
+  }
 
+  const root = vscode.workspace.workspaceFolders[0].uri.fsPath;
   const buildDir = workspaceRelative(extensionConfiguration("buildFolder"));
   explorer = new MesonProjectExplorer(ctx, root, buildDir);
   watcher = vscode.workspace.createFileSystemWatcher(`${workspaceRelative(extensionConfiguration("buildFolder"))}/build.ninja`, false, false, true);


### PR DESCRIPTION
Small tidy up to stop using deprecated `vscode.workspace.rootPath` (plus stylistically bad merge conflict resolution by me for the previous version...).
