### PR TITLE
refactor: move subprojects to bottom of top level node.

### DIFF
--- a/src/treeview/nodes/toplevel.ts
+++ b/src/treeview/nodes/toplevel.ts
@@ -29,16 +29,28 @@ export class ProjectNode extends BaseNode {
   }
 
   async getChildren() {
-    const children = [
+    let children: BaseNode[] = [
       new TargetDirectoryNode(`${this.id}-targets`,
         ".",
         (await getMesonTargets(this.buildDir)).filter((target) => !target.subproject)
-      ),
-      new TestRootNode(this.id, await getMesonTests(this.buildDir), false),
-      new TestRootNode(this.id, await getMesonBenchmarks(this.buildDir), true)
+      )
     ];
 
-    return (this.project.subprojects.length === 0) ? children : [...children, new SubprojectsRootNode(this.id, this.project.subprojects, this.buildDir)];
+    const tests = await getMesonTests(this.buildDir);
+    if (tests.length > 0) {
+      children.push(new TestRootNode(this.id, tests, false));
+    }
+
+    const benchmarks = await getMesonBenchmarks(this.buildDir);
+    if (benchmarks.length > 0) {
+      children.push(new TestRootNode(this.id, benchmarks, true));
+    }
+
+    if (this.project.subprojects.length > 0) {
+      children.push(new SubprojectsRootNode(this.id, this.project.subprojects, this.buildDir));
+    }
+
+    return children;
   }
 }
 

--- a/src/treeview/nodes/toplevel.ts
+++ b/src/treeview/nodes/toplevel.ts
@@ -29,8 +29,7 @@ export class ProjectNode extends BaseNode {
   }
 
   async getChildren() {
-    return [
-      new SubprojectsRootNode(this.id, this.project.subprojects, this.buildDir),
+    const children = [
       new TargetDirectoryNode(`${this.id}-targets`,
         ".",
         (await getMesonTargets(this.buildDir)).filter((target) => !target.subproject)
@@ -38,6 +37,8 @@ export class ProjectNode extends BaseNode {
       new TestRootNode(this.id, await getMesonTests(this.buildDir), false),
       new TestRootNode(this.id, await getMesonBenchmarks(this.buildDir), true)
     ];
+
+    return (this.project.subprojects.length === 0) ? children : [...children, new SubprojectsRootNode(this.id, this.project.subprojects, this.buildDir)];
   }
 }
 
@@ -55,7 +56,7 @@ class SubprojectsRootNode extends BaseNode {
 
     item.label = "Subprojects";
     item.iconPath = extensionRelative("res/icon-subprojects.svg");
-    item.collapsibleState = vscode.TreeItemCollapsibleState.Collapsed;
+    item.collapsibleState = (this.subprojects.length === 0) ? vscode.TreeItemCollapsibleState.None : vscode.TreeItemCollapsibleState.Collapsed;
 
     return item;
   }
@@ -79,7 +80,6 @@ class SubprojectNode extends BaseNode {
 
     item.label = `${this.subproject.descriptive_name} ${this.subproject.version}`;
     item.iconPath = extensionRelative("res/icon-subproject.svg");
-    item.collapsibleState = vscode.TreeItemCollapsibleState.Expanded;
 
     // No children currently, so don't display toggle.
     item.collapsibleState = vscode.TreeItemCollapsibleState.None;


### PR DESCRIPTION
They are currently uninteresting as you can't do anything with them so I think this is nicer.