### PR TITLE
Add debug configuration provider

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,9 @@
     "onCommand:mesonbuild.build",
     "onCommand:mesonbuild.test",
     "onCommand:mesonbuild.benchmark",
-    "workspaceContains:meson.build"
+    "workspaceContains:meson.build",
+    "onDebugDynamicConfigurations",
+    "onDebugDynamicConfigurations:cppdbg"
   ],
   "main": "./out/src/extension",
   "contributes": {

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
   },
   "homepage": "https://github.com/mesonbuild/vscode-meson/blob/master/README.md",
   "engines": {
-    "vscode": "^1.26.0"
+    "vscode": "^1.59.0"
   },
   "categories": [
     "Programming Languages"
@@ -209,7 +209,7 @@
   "devDependencies": {
     "@types/node": "^16.11.7",
     "typescript": "^4.4.4",
-    "vscode": "^1.1.37"
+    "@types/vscode": "^1.1.59"
   },
   "dependencies": {
     "array-flat-polyfill": "^1.0.1"

--- a/src/configprovider.ts
+++ b/src/configprovider.ts
@@ -17,15 +17,15 @@ export class DebugConfigurationProvider implements vscode.DebugConfigurationProv
     async provideDebugConfigurations(folder: vscode.WorkspaceFolder | undefined, token?: vscode.CancellationToken): Promise<vscode.DebugConfiguration[]> {
         let targets = await getMesonTargets(this.path);
 
-        let executables = targets.filter(target => target.type == "executable");
-        var ret: vscode.DebugConfiguration[] = [];
+        const executables = targets.filter(target => target.type == "executable");
+        let ret: vscode.DebugConfiguration[] = [];
 
-        for (let target of executables) {
+        for (const target of executables) {
             if (!target.target_sources.some(source => ['cpp', 'c'].includes(source.language))) {
                 continue;
             }
 
-            let targetName = await getTargetName(target)
+            const targetName = await getTargetName(target)
             ret.push({
                 type: 'cppdbg',
                 name: target.name,

--- a/src/configprovider.ts
+++ b/src/configprovider.ts
@@ -1,0 +1,37 @@
+import * as vscode from "vscode";
+
+import {
+    getMesonTargets
+} from "./meson/introspection"
+
+export class DebugConfigurationProvider implements vscode.DebugConfigurationProvider {
+    private path: string;
+
+    constructor(path: string) {
+        this.path = path
+    }
+
+    async provideDebugConfigurations(folder: vscode.WorkspaceFolder | undefined, token?: vscode.CancellationToken): Promise<vscode.DebugConfiguration[]> {
+        let targets = await getMesonTargets(this.path);
+
+        let executables = targets.filter(target => target.type == "executable");
+
+        return executables.map(target => {return {
+            type: 'cppdbg',
+            name: target.name,
+            request: "launch",
+            cwd: this.path,
+            program: target.filename[0]
+            //preLaunchTask: 
+        }; });
+    }
+
+    resolveDebugConfiguration(folder: vscode.WorkspaceFolder | undefined, debugConfiguration: vscode.DebugConfiguration, token?: vscode.CancellationToken): vscode.ProviderResult<vscode.DebugConfiguration> {
+        return debugConfiguration
+    }
+
+    resolveDebugConfigurationWithSubstitutedVariables(folder: vscode.WorkspaceFolder, debugConfiguration: vscode.DebugConfiguration, token?: vscode.CancellationToken): vscode.ProviderResult<vscode.DebugConfiguration> {
+        return debugConfiguration
+    }
+
+}

--- a/src/configprovider.ts
+++ b/src/configprovider.ts
@@ -21,6 +21,10 @@ export class DebugConfigurationProvider implements vscode.DebugConfigurationProv
         var ret: vscode.DebugConfiguration[] = [];
 
         for (let target of executables) {
+            if (!target.target_sources.some(source => ['cpp', 'c'].includes(source.language))) {
+                continue;
+            }
+
             let targetName = await getTargetName(target)
             ret.push({
                 type: 'cppdbg',

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -20,6 +20,8 @@ import {
   getMesonTests,
   getMesonBenchmarks
 } from "./meson/introspection";
+import {DebugConfigurationProvider} from "./configprovider";
+
 
 export let extensionPath: string;
 let explorer: MesonProjectExplorer;
@@ -36,6 +38,12 @@ export async function activate(ctx: vscode.ExtensionContext) {
   const buildDir = workspaceRelative(extensionConfiguration("buildFolder"));
   explorer = new MesonProjectExplorer(ctx, root, buildDir);
   watcher = vscode.workspace.createFileSystemWatcher(`${workspaceRelative(extensionConfiguration("buildFolder"))}/build.ninja`, false, false, true);
+
+  ctx.subscriptions.push(
+    vscode.debug.registerDebugConfigurationProvider('cppdbg',
+      new DebugConfigurationProvider(workspaceRelative(extensionConfiguration("buildFolder"))),
+      vscode.DebugConfigurationProviderTriggerKind.Dynamic)
+  );
 
   ctx.subscriptions.push(watcher);
 

--- a/src/treeview/index.ts
+++ b/src/treeview/index.ts
@@ -18,7 +18,7 @@ class MesonProjectDataProvider implements vscode.TreeDataProvider<BaseNode> {
   }
 
   refresh() {
-    this._onDataChangeEmitter.fire();
+    this._onDataChangeEmitter.fire(null);
   }
 
   getTreeItem(element: BaseNode) {


### PR DESCRIPTION
Planned todo: Add the build task of the debugged executable as preLaunchTask to force a rebuild.

Shares the first commit with https://github.com/mesonbuild/vscode-meson/pull/57

supersedes https://github.com/mesonbuild/vscode-meson/pull/23 IMO
Fixes #21 