### PR TITLE
Fix extension path

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -21,10 +21,13 @@ import {
   getMesonBenchmarks
 } from "./meson/introspection";
 
+export let extensionPath: string;
 let explorer: MesonProjectExplorer;
 let watcher: vscode.FileSystemWatcher;
 
 export async function activate(ctx: vscode.ExtensionContext) {
+  extensionPath = ctx.extensionPath;
+
   const root = vscode.workspace.rootPath;
   if (!root) {
     return

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -6,6 +6,7 @@ import { createHash, BinaryLike } from "crypto";
 import { Target } from "./meson/types";
 import { ExtensionConfiguration } from "./types";
 import { getMesonBuildOptions } from "./meson/introspection";
+import { extensionPath } from "./extension";
 
 export async function exec(
   command: string,
@@ -81,19 +82,8 @@ export function getOutputChannel(): vscode.OutputChannel {
   return _channel;
 }
 
-export function thisExtension() {
-  const ext = vscode.extensions.getExtension("mesonbuild.mesonbuild");
-
-  if (ext) {
-    return ext;
-  }
-  else {
-    throw new Error("Extension not found");
-  }
-}
-
 export function extensionRelative(filepath: string) {
-  return path.join(thisExtension().extensionPath, filepath);
+  return path.join(extensionPath, filepath);
 }
 
 export function workspaceRelative(filepath: string) {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,10 +1,8 @@
-"use strict";
-
 import * as fs from "fs";
 import * as path from "path";
 import * as cp from "child_process";
 import * as vscode from "vscode";
-import { randomBytes, createHash, BinaryLike } from "crypto";
+import { createHash, BinaryLike } from "crypto";
 import { Target } from "./meson/types";
 import { ExtensionConfiguration } from "./types";
 import { getMesonBuildOptions } from "./meson/introspection";
@@ -84,9 +82,14 @@ export function getOutputChannel(): vscode.OutputChannel {
 }
 
 export function thisExtension() {
-  const ext = vscode.extensions.getExtension("mesonbuild.meson");
-  if (ext) return ext;
-  else throw new Error("Extension not found");
+  const ext = vscode.extensions.getExtension("mesonbuild.mesonbuild");
+
+  if (ext) {
+    return ext;
+  }
+  else {
+    throw new Error("Extension not found");
+  }
 }
 
 export function extensionRelative(filepath: string) {


### PR DESCRIPTION
Per #59.

There's two commits here - first is a quick fix to change the "publisher.package" string that was broken by the package name change.

Second commit caches the extension's path from activation. Decouples from the name of the extension (and saves all those calls to getExtension()), though I don't really like having a globalish like that.

Looking at all the uses, it shouldn't be too much work to refactor to pass the extension context through to where it's needed. I don't mind looking at that if commit 2 isn't palatable, but at least the first commit should fix the problem for now!

Cheers
