### PR TITLE
fix: correctly process absolute path in `mesonbuild.buildFolder`

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -87,7 +87,7 @@ export function extensionRelative(filepath: string) {
 }
 
 export function workspaceRelative(filepath: string) {
-  return path.join(vscode.workspace.rootPath, filepath);
+  return path.resolve(vscode.workspace.rootPath, filepath);
 }
 
 export async function getTargetName(target: Target) {


### PR DESCRIPTION
Currently it's treated not as an absolute one, but as a relative to the workspace.
So `/tmp/project-build` resolves to `<WORKSPACE_FOLDER>/tmp/project-build`.
[`path.resolve`](https://nodejs.org/api/path.html#pathresolvepaths) will take care of that.