### PR TITLE
Add mesonpath

### DIFF
--- a/package.json
+++ b/package.json
@@ -108,6 +108,11 @@
             "--buildtype=debug"
           ],
           "description": "Specify the list of configuration options used for Meson configuration."
+        },
+        "mesonbuild.mesonPath": {
+          "type": "string",
+          "default": "meson",
+          "description": "Specify the meson executable to use"
         }
       }
     },

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -130,7 +130,7 @@ export async function activate(ctx: vscode.ExtensionContext) {
 
   ctx.subscriptions.push(
     vscode.commands.registerCommand("mesonbuild.clean", async () => {
-      await execAsTask("meson", ["compile", "--clean"], {
+      await execAsTask(extensionConfiguration("mesonPath"), ["compile", "--clean"], {
         cwd: workspaceRelative(extensionConfiguration("buildFolder"))
       });
     })

--- a/src/meson/introspection.ts
+++ b/src/meson/introspection.ts
@@ -1,5 +1,5 @@
 import * as path from "path";
-import { exec, parseJSONFileIfExists } from "../utils";
+import { exec, extensionConfiguration, parseJSONFileIfExists } from "../utils";
 import {
   Targets,
   Dependencies,
@@ -12,12 +12,11 @@ async function introspectMeson<T>(buildDir: string, filename: string, introspect
   const parsed = await parseJSONFileIfExists<T>(
     path.join(buildDir, path.join("meson-info", filename))
   );
-
   if (parsed) {
     return parsed;
   }
 
-  const { stdout } = await exec("meson", ["introspect", introspectSwitch], {
+  const { stdout } = await exec(extensionConfiguration("mesonPath"), ["introspect", introspectSwitch], {
     cwd: buildDir
   });
 
@@ -59,7 +58,7 @@ export async function getMesonBenchmarks(buildDir: string) {
 export async function getMesonVersion(): Promise<[number, number, number]> {
   const MESON_VERSION_REGEX = /^(\d+)\.(\d+)\.(\d+)/g;
 
-  const { stdout } = await exec("meson", ["--version"]);
+  const { stdout } = await exec(extensionConfiguration("mesonPath"), ["--version"]);
   const match = stdout.trim().match(MESON_VERSION_REGEX);
   if (match) {
     return match.slice(1, 3).map(s => Number.parseInt(s)) as [

--- a/src/meson/runners.ts
+++ b/src/meson/runners.ts
@@ -34,13 +34,13 @@ export async function runMesonConfigure(source: string, build: string) {
         });
 
         await exec(
-          "meson", ["configure", configureOpts, build],
+          extensionConfiguration("mesonPath"), ["configure", configureOpts, build],
           { cwd: source }
         );
         progress.report({ message: "Reconfiguring build...", increment: 60 });
 
         // Note "setup --reconfigure" needs to be run from the root.
-        await exec("meson", ["setup", "--reconfigure", build],
+        await exec(extensionConfiguration("mesonPath"), ["setup", "--reconfigure", build],
           { cwd: source });
       } else {
         progress.report({
@@ -48,7 +48,7 @@ export async function runMesonConfigure(source: string, build: string) {
         });
 
         const { stdout, stderr } = await exec(
-          "meson", ["setup", configureOpts, build],
+          extensionConfiguration("mesonPath"), ["setup", configureOpts, build],
           { cwd: source });
 
         getOutputChannel().appendLine(stdout);
@@ -80,7 +80,7 @@ export async function runMesonBuild(buildDir: string, name?: string) {
   getOutputChannel().append(`\n${title}\n`);
 
   const args = ["compile"].concat(name ?? []);
-  const stream = execStream("meson", args, { cwd: buildDir });
+  const stream = execStream(extensionConfiguration("mesonPath"), args, { cwd: buildDir });
 
   return vscode.window.withProgress(
     {
@@ -122,7 +122,7 @@ export async function runMesonTests(buildDir: string, isBenchmark: boolean, name
     const benchmarkArgs = isBenchmark ? ["--benchmark", "--verbose"] : [];
     const args = ["test", ...benchmarkArgs].concat(name ?? []);
     return await execAsTask(
-      "meson", args,
+      extensionConfiguration("mesonPath"), args,
       { cwd: buildDir },
       vscode.TaskRevealKind.Always
     );

--- a/src/tasks.ts
+++ b/src/tasks.ts
@@ -4,7 +4,7 @@ import {
   getMesonTests,
   getMesonBenchmarks
 } from "./meson/introspection";
-import { getOutputChannel, getTargetName } from "./utils";
+import { extensionConfiguration, getOutputChannel, getTargetName } from "./utils";
 
 interface MesonTaskDefinition extends vscode.TaskDefinition {
   type: "meson";
@@ -24,33 +24,33 @@ export async function getMesonTasks(buildDir: string): Promise<vscode.Task[]> {
       { type: "meson", mode: "build" },
       "Build all targets",
       "Meson",
-      new vscode.ProcessExecution("meson", ["compile"], { cwd: buildDir })
+      new vscode.ProcessExecution(extensionConfiguration("mesonPath"), ["compile"], { cwd: buildDir })
     );
     const defaultTestTask = new vscode.Task(
       { type: "meson", mode: "test" },
       "Run tests",
       "Meson",
-      new vscode.ProcessExecution("meson", ["test"], { cwd: buildDir })
+      new vscode.ProcessExecution(extensionConfiguration("mesonPath"), ["test"], { cwd: buildDir })
     );
     const defaultBenchmarkTask = new vscode.Task(
       { type: "meson", mode: "benchmark" },
       "Run benchmarks",
       "Meson",
-      new vscode.ProcessExecution("meson", ["test", "--benchmark", "--verbose"], { cwd: buildDir })
+      new vscode.ProcessExecution(extensionConfiguration("mesonPath"), ["test", "--benchmark", "--verbose"], { cwd: buildDir })
     );
     const defaultReconfigureTask = new vscode.Task(
       { type: "meson", mode: "reconfigure" },
       "Reconfigure",
       "Meson",
       // Note "setup --reconfigure" needs to be run from the root.
-      new vscode.ProcessExecution("meson", ["setup", "--reconfigure", buildDir],
+      new vscode.ProcessExecution(extensionConfiguration("mesonPath"), ["setup", "--reconfigure", buildDir],
         { cwd: vscode.workspace.rootPath })
     );
     const defaultCleanTask = new vscode.Task(
       { type: "meson", mode: "clean" },
       "Clean",
       "Meson",
-      new vscode.ProcessExecution("meson", ["compile", "--clean"], { cwd: buildDir })
+      new vscode.ProcessExecution(extensionConfiguration("mesonPath"), ["compile", "--clean"], { cwd: buildDir })
     );
     defaultBuildTask.group = vscode.TaskGroup.Build;
     defaultTestTask.group = vscode.TaskGroup.Test;
@@ -77,7 +77,7 @@ export async function getMesonTasks(buildDir: string): Promise<vscode.Task[]> {
             def,
             `Build ${targetName}`,
             "Meson",
-            new vscode.ProcessExecution("meson", ["compile", targetName], {
+            new vscode.ProcessExecution(extensionConfiguration("mesonPath"), ["compile", targetName], {
               cwd: buildDir
             })
           );
@@ -121,7 +121,7 @@ export async function getMesonTasks(buildDir: string): Promise<vscode.Task[]> {
           { type: "meson", mode: "test", target: t.name },
           `Test ${t.name}`,
           "Meson",
-          new vscode.ProcessExecution("meson", ["test", t.name], {
+          new vscode.ProcessExecution(extensionConfiguration("mesonPath"), ["test", t.name], {
             env: t.env,
             cwd: buildDir
           })
@@ -134,7 +134,7 @@ export async function getMesonTasks(buildDir: string): Promise<vscode.Task[]> {
           { type: "meson", mode: "benchmark", target: b.name },
           `Benchmark ${b.name}`,
           "Meson",
-          new vscode.ProcessExecution("meson", ["test", "--benchmark", "--verbose", b.name], {
+          new vscode.ProcessExecution(extensionConfiguration("mesonPath"), ["test", "--benchmark", "--verbose", b.name], {
             env: b.env,
             cwd: buildDir
           })

--- a/src/types.ts
+++ b/src/types.ts
@@ -4,4 +4,5 @@ export interface ExtensionConfiguration {
   configureOnOpen: boolean | "ask";
   configureOptions: string[];
   buildFolder: string;
+  mesonPath: string;
 }


### PR DESCRIPTION
This merges #29 and updates the changes for new developments that happened since.
Notably, it removes the ninjaPath configuration again, since ninja isn't invoked directly anymore.

While this and #57 don't collide, they need to be updated when one is pulled, since there's a new invocation for tests.

closes #29 