### PR TITLE
ci: split api check into a separate job and fix indentation

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,7 +20,11 @@ jobs:
       run: yarn install
     - name: tsc
       run: tsc --noEmit --noErrorTruncation --pretty false
+  api-check:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v1
     - name: Check Meson API
-        run: |
-          git clone https://github.com/mesonbuild/meson
-          ./ci/check-meson-api.py
+      run: |
+        git clone https://github.com/mesonbuild/meson --depth 1
+        ./ci/check-meson-api.py


### PR DESCRIPTION
also clone with a depth of 1, for time savings.

I broke the CI by merging something that wasn't ready, I guess that makes it my problem to fix.