### PR TITLE
Fix concatenation of multiple arguments

### DIFF
--- a/src/meson/runners.ts
+++ b/src/meson/runners.ts
@@ -25,7 +25,7 @@ export async function runMesonConfigure(source: string, build: string) {
         )}...`
       });
 
-      const configureOpts = extensionConfiguration("configureOptions").join(" ");
+      const configureOpts = extensionConfiguration("configureOptions");
 
       if (await checkMesonIsConfigured(build)) {
         progress.report({
@@ -34,7 +34,7 @@ export async function runMesonConfigure(source: string, build: string) {
         });
 
         await exec(
-          extensionConfiguration("mesonPath"), ["configure", configureOpts, build],
+          extensionConfiguration("mesonPath"), ["configure", ...configureOpts, build],
           { cwd: source }
         );
         progress.report({ message: "Reconfiguring build...", increment: 60 });
@@ -48,7 +48,7 @@ export async function runMesonConfigure(source: string, build: string) {
         });
 
         const { stdout, stderr } = await exec(
-          extensionConfiguration("mesonPath"), ["setup", configureOpts, build],
+          extensionConfiguration("mesonPath"), ["setup", ...configureOpts, build],
           { cwd: source });
 
         getOutputChannel().appendLine(stdout);


### PR DESCRIPTION
When using more than one argument for setup, they all get concatenated together, making the first one the only recognized and its parameter being the concatenation of all the rest of the lines.