### PR TITLE
replace "provider" with a link to muon in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Icons from the [Material Design Icons](https://materialdesignicons.com/) project
 - Linting\*
 - Formatting\*
 
-\* - requires a supported provider be installed
+\* - requires an installation of [muon](https://muon.build).
 
 # New extension ID
 


### PR DESCRIPTION
Fixes #89.