### PR TITLE
Can open meson.build from treeview

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,6 +52,12 @@
   "contributes": {
     "commands": [
       {
+        "command": "mesonbuild.openBuildFile",
+        "title": "Open",
+        "icon": "$(preferences-open-settings)",
+        "when": "false"
+      },
+      {
         "command": "mesonbuild.configure",
         "title": "Meson: Configure"
       },
@@ -249,6 +255,15 @@
           "id": "meson-project",
           "name": "Current project",
           "when": "mesonbuild.hasProject"
+        }
+      ]
+    },
+    "menus": {
+      "view/item/context": [
+        {
+          "command": "mesonbuild.openBuildFile",
+          "when": "view == meson-project && viewItem == meson-target",
+          "group": "inline"
         }
       ]
     },

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -8,6 +8,7 @@ import {
 } from "./meson/runners";
 import { getMesonTasks } from "./tasks";
 import { MesonProjectExplorer } from "./treeview";
+import { TargetNode } from "./treeview/nodes/targets"
 import {
   extensionConfiguration,
   execAsTask,
@@ -97,6 +98,15 @@ export async function activate(ctx: vscode.ExtensionContext) {
       }
     })
   );
+
+  ctx.subscriptions.push(
+    vscode.commands.registerCommand("mesonbuild.openBuildFile", async (node: TargetNode) => {
+      let file = node.getTarget().defined_in;
+      let uri  = vscode.Uri.file(file)
+      await vscode.commands.executeCommand('vscode.open', uri);
+      })
+  );
+
 
   ctx.subscriptions.push(
     vscode.commands.registerCommand("mesonbuild.configure", async () => {

--- a/src/treeview/nodes/targets.ts
+++ b/src/treeview/nodes/targets.ts
@@ -72,6 +72,10 @@ export class TargetNode extends BaseNode {
     super(`${parentId}-${target.id}`);
   }
 
+  getTarget() {
+    return this.target;
+  }
+
   getChildren() {
     if (!this.target.target_sources) {
       return [];
@@ -95,6 +99,7 @@ export class TargetNode extends BaseNode {
     item.label = this.target.name;
     item.iconPath = extensionRelative(this.getIconPath());
     item.collapsibleState = vscode.TreeItemCollapsibleState.Collapsed;
+    item.contextValue = "meson-target";
 
     const targetName = await getTargetName(this.target);
 


### PR DESCRIPTION
The treeview will have an open-file button for each target.
This will open the build.meson file where the target is defined.