### PR TITLE
Do not reconfigure on vscode startup

### DIFF
--- a/src/meson/runners.ts
+++ b/src/meson/runners.ts
@@ -28,22 +28,7 @@ export async function runMesonConfigure(source: string, build: string) {
       const configureOpts = extensionConfiguration("configureOptions");
       const setupOpts = extensionConfiguration("setupOptions");
 
-      if (await checkMesonIsConfigured(build)) {
-        progress.report({
-          message: "Applying configure options...",
-          increment: 30
-        });
-
-        await exec(
-          extensionConfiguration("mesonPath"), ["configure", ...configureOpts, build],
-          { cwd: source }
-        );
-        progress.report({ message: "Reconfiguring build...", increment: 60 });
-
-        // Note "setup --reconfigure" needs to be run from the root.
-        await exec(extensionConfiguration("mesonPath"), ["setup", "--reconfigure", ...setupOpts, build],
-          { cwd: source });
-      } else {
+      if (!await checkMesonIsConfigured(build)) {
         progress.report({
           message: `Configuring Meson into ${relative(source, build)}...`
         });


### PR DESCRIPTION
Reconfiguring a project can be slow, especially when having lots of subprojects. Once the project has been configured, there is no reason to reconfigure it on startup, a rebuild will reconfigure only if needed.