### PR TITLE
Apply format defined in .editorconfig

### DIFF
--- a/src/configprovider.ts
+++ b/src/configprovider.ts
@@ -1,54 +1,54 @@
 import * as vscode from "vscode";
 
 import {
-    getMesonTargets
+  getMesonTargets
 } from "./meson/introspection"
 import {
-    extensionConfiguration,
-    getTargetName
+  extensionConfiguration,
+  getTargetName
 } from "./utils"
 
 export class DebugConfigurationProvider implements vscode.DebugConfigurationProvider {
-    private path: string;
+  private path: string;
 
-    constructor(path: string) {
-        this.path = path
+  constructor(path: string) {
+    this.path = path
+  }
+
+  async provideDebugConfigurations(folder: vscode.WorkspaceFolder | undefined, token?: vscode.CancellationToken): Promise<vscode.DebugConfiguration[]> {
+    let targets = await getMesonTargets(this.path);
+
+    let configDebugOptions = extensionConfiguration("debugOptions");
+
+    const executables = targets.filter(target => target.type == "executable");
+    let ret: vscode.DebugConfiguration[] = [];
+
+    for (const target of executables) {
+      if (!target.target_sources.some(source => ['cpp', 'c'].includes(source.language))) {
+        continue;
+      }
+
+      const targetName = await getTargetName(target)
+      let debugConfiguration = {
+        type: 'cppdbg',
+        name: target.name,
+        request: "launch",
+        cwd: this.path,
+        program: target.filename[0],
+        preLaunchTask: `Meson: Build ${targetName}`
+      };
+      ret.push({ ...configDebugOptions, ...debugConfiguration })
     }
 
-    async provideDebugConfigurations(folder: vscode.WorkspaceFolder | undefined, token?: vscode.CancellationToken): Promise<vscode.DebugConfiguration[]> {
-        let targets = await getMesonTargets(this.path);
+    return ret;
+  }
 
-        let configDebugOptions = extensionConfiguration("debugOptions");
+  resolveDebugConfiguration(folder: vscode.WorkspaceFolder | undefined, debugConfiguration: vscode.DebugConfiguration, token?: vscode.CancellationToken): vscode.ProviderResult<vscode.DebugConfiguration> {
+    return debugConfiguration
+  }
 
-        const executables = targets.filter(target => target.type == "executable");
-        let ret: vscode.DebugConfiguration[] = [];
-
-        for (const target of executables) {
-            if (!target.target_sources.some(source => ['cpp', 'c'].includes(source.language))) {
-                continue;
-            }
-
-            const targetName = await getTargetName(target)
-            let debugConfiguration = {
-                type: 'cppdbg',
-                name: target.name,
-                request: "launch",
-                cwd: this.path,
-                program: target.filename[0],
-                preLaunchTask: `Meson: Build ${targetName}`
-            };
-            ret.push({...configDebugOptions, ...debugConfiguration})
-        }
-
-        return ret;
-    }
-
-    resolveDebugConfiguration(folder: vscode.WorkspaceFolder | undefined, debugConfiguration: vscode.DebugConfiguration, token?: vscode.CancellationToken): vscode.ProviderResult<vscode.DebugConfiguration> {
-        return debugConfiguration
-    }
-
-    resolveDebugConfigurationWithSubstitutedVariables(folder: vscode.WorkspaceFolder, debugConfiguration: vscode.DebugConfiguration, token?: vscode.CancellationToken): vscode.ProviderResult<vscode.DebugConfiguration> {
-        return debugConfiguration
-    }
+  resolveDebugConfigurationWithSubstitutedVariables(folder: vscode.WorkspaceFolder, debugConfiguration: vscode.DebugConfiguration, token?: vscode.CancellationToken): vscode.ProviderResult<vscode.DebugConfiguration> {
+    return debugConfiguration
+  }
 
 }

--- a/src/tests.ts
+++ b/src/tests.ts
@@ -5,110 +5,110 @@ import {
   workspaceRelative,
 } from "./utils";
 import {
-    Tests
+  Tests
 } from "./meson/types"
 import {
-    getMesonTests,
-    getMesonTargets
+  getMesonTests,
+  getMesonTargets
 } from "./meson/introspection"
 
 export async function rebuildTests(controller: vscode.TestController) {
-    let tests = await getMesonTests(workspaceRelative(extensionConfiguration("buildFolder")))
+  let tests = await getMesonTests(workspaceRelative(extensionConfiguration("buildFolder")))
 
-    controller.items.forEach(item => {
-      if (!tests.some(test => item.id == test.name)) {
-        controller.items.delete(item.id);
+  controller.items.forEach(item => {
+    if (!tests.some(test => item.id == test.name)) {
+      controller.items.delete(item.id);
+    }
+  });
+
+  for (let testDescr of tests) {
+    let testItem = controller.createTestItem(testDescr.name, testDescr.name)
+    controller.items.add(testItem)
+  }
+}
+
+export async function testRunHandler(controller: vscode.TestController, request: vscode.TestRunRequest, token: vscode.CancellationToken) {
+  const run = controller.createTestRun(request, null, false);
+  const queue: vscode.TestItem[] = [];
+
+  if (request.include) {
+    request.include.forEach(test => queue.push(test));
+  } else {
+    controller.items.forEach(test => queue.push(test));
+  }
+
+  for (let test of queue) {
+    run.started(test);
+    let starttime = Date.now();
+    try {
+      await exec(extensionConfiguration("mesonPath"), ['test', '-C', workspaceRelative(extensionConfiguration("buildFolder")), '--print-errorlog', test.id]);
+      let duration = Date.now() - starttime;
+      run.passed(test, duration);
+    } catch (e) {
+      run.appendOutput(e.stdout);
+      let duration = Date.now() - starttime;
+      if (e.error.code == 125) {
+        vscode.window.showErrorMessage("Failed to build tests. Results will not be updated");
+        run.errored(test, new vscode.TestMessage(e.stderr));
+      } else {
+        run.failed(test, new vscode.TestMessage(e.stderr), duration);
       }
-    });
-
-    for (let testDescr of tests) {
-      let testItem = controller.createTestItem(testDescr.name, testDescr.name)
-      controller.items.add(testItem)
     }
   }
 
-export async function testRunHandler(controller: vscode.TestController, request: vscode.TestRunRequest, token: vscode.CancellationToken) {
-    const run = controller.createTestRun(request, null, false);
-    const queue: vscode.TestItem[] = [];
-
-    if (request.include) {
-        request.include.forEach(test => queue.push(test));
-    } else {
-        controller.items.forEach(test => queue.push(test));
-    }
-
-    for (let test of queue) {
-        run.started(test);
-        let starttime = Date.now();
-        try {
-            await exec(extensionConfiguration("mesonPath"), ['test', '-C', workspaceRelative(extensionConfiguration("buildFolder")), '--print-errorlog', test.id]);
-            let duration = Date.now() - starttime;
-            run.passed(test, duration);
-        } catch (e) {
-            run.appendOutput(e.stdout);
-            let duration = Date.now() - starttime;
-            if (e.error.code == 125) {
-                vscode.window.showErrorMessage("Failed to build tests. Results will not be updated");
-                run.errored(test, new vscode.TestMessage(e.stderr));
-            } else {
-                run.failed(test, new vscode.TestMessage(e.stderr), duration);
-            }
-        }
-    }
-
-    run.end();
+  run.end();
 }
 
 export async function testDebugHandler(controller: vscode.TestController, request: vscode.TestRunRequest, token: vscode.CancellationToken) {
-    const run = controller.createTestRun(request, null, false);
-    const queue: vscode.TestItem[] = [];
+  const run = controller.createTestRun(request, null, false);
+  const queue: vscode.TestItem[] = [];
 
-    if (request.include) {
-        request.include.forEach(test => queue.push(test));
-    } else {
-        controller.items.forEach(test => queue.push(test));
-    }
+  if (request.include) {
+    request.include.forEach(test => queue.push(test));
+  } else {
+    controller.items.forEach(test => queue.push(test));
+  }
 
-    const tests: Tests = await getMesonTests(workspaceRelative(extensionConfiguration("buildFolder")));
-    const targets = await getMesonTargets(workspaceRelative(extensionConfiguration("buildFolder")));
+  const tests: Tests = await getMesonTests(workspaceRelative(extensionConfiguration("buildFolder")));
+  const targets = await getMesonTargets(workspaceRelative(extensionConfiguration("buildFolder")));
 
-    /* while meson has the --gdb arg to test, but IMO we should go the actual debugger route.
-     * We still want stuff to be built though... Without going through weird dances */
-    const relevantTests = tests.filter(test => queue.some(candidate => candidate.id == test.name));
-    const requiredTargets = targets.filter(target => relevantTests.some(test => test.depends.some(dep => dep == target.id)));
+  /* while meson has the --gdb arg to test, but IMO we should go the actual debugger route.
+   * We still want stuff to be built though... Without going through weird dances */
+  const relevantTests = tests.filter(test => queue.some(candidate => candidate.id == test.name));
+  const requiredTargets = targets.filter(target => relevantTests.some(test => test.depends.some(dep => dep == target.id)));
 
-    var args = ['compile', '-C', workspaceRelative(extensionConfiguration("buildFolder"))]
-    requiredTargets.forEach(target => {
-        args.push(target.name);
-    });
+  var args = ['compile', '-C', workspaceRelative(extensionConfiguration("buildFolder"))]
+  requiredTargets.forEach(target => {
+    args.push(target.name);
+  });
 
-    try {
-        await exec(extensionConfiguration("mesonPath"), args);
-    } catch(e) {
-        vscode.window.showErrorMessage("Failed to build tests. Results will not be updated");
-        run.end();
-        return;
-    }
-
-    let configDebugOptions = extensionConfiguration("debugOptions")
-
-    /* We already figured out which tests we want to run.
-     * We don't use the actual test either way, as we don't get the result here... */
-    for (let test of relevantTests) {
-        let args = [...test.cmd]
-        args.shift();
-
-        let debugConfiguration = {
-                name: `meson-debug-${test.name}`,
-                type: "cppdbg",
-                request: "launch",
-                cwd: test.workdir || workspaceRelative(extensionConfiguration("buildFolder")),
-                env: test.env,
-                program: test.cmd[0],
-                args: args,
-            };
-        await vscode.debug.startDebugging(undefined, {...debugConfiguration, ...configDebugOptions});
-    }
-
+  try {
+    await exec(extensionConfiguration("mesonPath"), args);
+  } catch (e) {
+    vscode.window.showErrorMessage("Failed to build tests. Results will not be updated");
     run.end();
+    return;
+  }
+
+  let configDebugOptions = extensionConfiguration("debugOptions")
+
+  /* We already figured out which tests we want to run.
+   * We don't use the actual test either way, as we don't get the result here... */
+  for (let test of relevantTests) {
+    let args = [...test.cmd]
+    args.shift();
+
+    let debugConfiguration = {
+      name: `meson-debug-${test.name}`,
+      type: "cppdbg",
+      request: "launch",
+      cwd: test.workdir || workspaceRelative(extensionConfiguration("buildFolder")),
+      env: test.env,
+      program: test.cmd[0],
+      args: args,
+    };
+    await vscode.debug.startDebugging(undefined, { ...debugConfiguration, ...configDebugOptions });
+  }
+
+  run.end();
 }

--- a/src/tools/muon.ts
+++ b/src/tools/muon.ts
@@ -97,7 +97,7 @@ export async function check(): Promise<{ tool: Tool, error: string }> {
   try {
     ({ stdout, stderr } = await exec(muon_path, ["version"]))
   } catch (exception) {
-    const {error, stdout, stderr}: {error: cp.ExecException, stdout: string, stderr: string} = exception;
+    const { error, stdout, stderr }: { error: cp.ExecException, stdout: string, stderr: string } = exception;
     console.log(error);
     return { tool: undef_muon, error: error.message };
   }


### PR DESCRIPTION
Some files are not correctly formatted based on the .editorconfig definitions.