### PR TITLE
Use autodetect for meson-gcc problem matcher.

### DIFF
--- a/package.json
+++ b/package.json
@@ -294,7 +294,7 @@
         "source": "gcc",
         "owner": "meson",
         "fileLocation": [
-          "relative",
+          "autodetect",
           "${workspaceFolder}/${config:mesonbuild.buildFolder}"
         ],
         "pattern": {


### PR DESCRIPTION
E.g. for errors in system-wide includes.