### PR TITLE
Remove vscode-nls

### DIFF
--- a/package.json
+++ b/package.json
@@ -316,8 +316,7 @@
   "devDependencies": {
     "@types/node": "^16.11.7",
     "@types/vscode": "^1.1.59",
-    "typescript": "^4.4.4",
-    "vscode-nls": "^5.0.0"
+    "typescript": "^4.4.4"
   },
   "dependencies": {}
 }

--- a/src/configprovider.ts
+++ b/src/configprovider.ts
@@ -1,5 +1,4 @@
 import * as vscode from "vscode";
-import * as nls from 'vscode-nls';
 import * as path from 'path';
 import {
   getMesonTargets
@@ -11,9 +10,6 @@ import {
   extensionConfiguration,
   getTargetName
 } from "./utils"
-
-nls.config({ messageFormat: nls.MessageFormat.bundle, bundleFormat: nls.BundleFormat.standalone })();
-const localize: nls.LocalizeFunc = nls.loadMessageBundle();
 
 export enum MIModes {
   lldb = 'lldb',
@@ -44,7 +40,7 @@ export class DebugConfigurationProvider implements vscode.DebugConfigurationProv
     let debugConfig = await this.createBaseDebugConfiguration(target);
     debugConfig.MIMode = MIModes.gdb;
     debugConfig.setupCommands = [{
-      description: localize('enable.pretty.printing', 'Enable pretty-printing for gdb'),
+      description: 'Enable pretty-printing for gdb',
       text: '-enable-pretty-printing',
       ignoreFailures: true
     }];


### PR DESCRIPTION
It is causing the extension to fail to activate:
```
[error] Activating extension mesonbuild.mesonbuild failed due to an error:
[error] Error: Cannot find module 'vscode-nls'
```

There seems to be a new mechanism with vscode-l10n but since we were not doing translations anyway, let's drop it for now.