### PR TITLE
Add a new command to run executables

### DIFF
--- a/package.json
+++ b/package.json
@@ -81,6 +81,10 @@
         "title": "Meson: Run Unit Tests"
       },
       {
+        "command": "mesonbuild.run",
+        "title": "Meson: Run Executable"
+      },
+      {
         "command": "mesonbuild.install",
         "title": "Meson: Install"
       },

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -7,7 +7,7 @@ import {
   runMesonReconfigure,
   runMesonInstall
 } from "./meson/runners";
-import { getMesonTasks } from "./tasks";
+import { getMesonTasks, getTask, getTasks } from "./tasks";
 import { MesonProjectExplorer } from "./treeview";
 import { TargetNode } from "./treeview/nodes/targets"
 import {
@@ -36,6 +36,7 @@ import {
 import {
   activateFormatters
 } from "./formatters"
+import { TaskQuickPickItem } from "./types";
 
 export let extensionPath: string;
 let explorer: MesonProjectExplorer;
@@ -186,6 +187,12 @@ export async function activate(ctx: vscode.ExtensionContext) {
     })
   );
 
+  ctx.subscriptions.push(
+    vscode.commands.registerCommand("mesonbuild.run", async () => {
+      runExecutable();
+    })
+  );
+
   const configureOnOpenKey = "configureOnOpen";
   let configureOnOpen = extensionConfiguration(configureOnOpenKey);
   if (configureOnOpen === "ask") {
@@ -306,6 +313,48 @@ export async function activate(ctx: vscode.ExtensionContext) {
       // Pick cancelled.
     }
 
+    explorer.refresh();
+  }
+
+  async function pickExecutable() {
+    const picker = vscode.window.createQuickPick<TaskQuickPickItem>();
+    picker.busy = true;
+    picker.placeholder = "Select target to run.";
+    picker.show();
+
+    const runnableTasks = await getTasks('run');
+
+    picker.busy = false;
+    picker.items = runnableTasks.map(task => {
+      return {
+        label: task.definition.target,
+        detail: task.name,
+        description: "executable",
+        picked: false,
+        task: task,
+      }
+    });
+
+    return new Promise<TaskQuickPickItem>((resolve, reject) => {
+      picker.onDidAccept(() => {
+        const selection = picker.activeItems[0];
+        resolve(selection);
+        picker.dispose();
+      });
+      picker.onDidHide(() => reject());
+    });
+  }
+
+  async function runExecutable() {
+    let taskItem;
+    try {
+      taskItem = await pickExecutable();
+    } catch (err) {
+      // Pick cancelled.
+    }
+    if (taskItem != null) {
+      await vscode.tasks.executeTask(taskItem.task);
+    }
     explorer.refresh();
   }
 }

--- a/src/tasks.ts
+++ b/src/tasks.ts
@@ -173,3 +173,10 @@ export async function getTask(mode: string, name?: string) {
     throw new Error(`Cannot find ${mode} target ${name}.`);
   return filtered[0];
 }
+
+export async function getTasks(mode: string) {
+  const tasks = await vscode.tasks.fetchTasks({ type: "meson" });
+  return tasks.filter(
+    t => t.definition.mode === mode
+  );
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,5 @@
 import * as vscode from "vscode";
+import { Target } from "./meson/types";
 
 export type Tool = { path: string, version: [number, number, number] }
 export type ToolCheckFunc = () => Promise<{ tool: Tool, error: string }>
@@ -24,4 +25,8 @@ export interface ExtensionConfiguration {
     muonConfig: string | null,
   };
   debugOptions: object;
+}
+
+export interface TaskQuickPickItem extends vscode.QuickPickItem {
+  task: vscode.Task;
 }


### PR DESCRIPTION
This adds a new command named `Meson: Run Executable` that lets the user select from a list of all the executables targets and run one of them, similar to how `Meson: Run Unit Tests` works.

CC @xclaesse 