### PR TITLE
extension: reload window if buildFolder changes.

### DIFF
--- a/package.json
+++ b/package.json
@@ -112,7 +112,7 @@
         "mesonbuild.buildFolder": {
           "type": "string",
           "default": "builddir",
-          "description": "Specify in which folder Meson build configure and build the project."
+          "description": "Specify in which folder Meson build configure and build the project. Changing this value will reload the VS Code window."
         },
         "mesonbuild.configureOptions": {
           "type": "array",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -94,10 +94,13 @@ export async function activate(ctx: vscode.ExtensionContext) {
   ctx.subscriptions.push(watcher);
   await genEnvFile(buildDir);
 
-  // Refresh if the extension configuration is changed. builddir changes won't be reflected, however.
+  // Refresh if the extension configuration is changed.
   ctx.subscriptions.push(
     vscode.workspace.onDidChangeConfiguration((e: vscode.ConfigurationChangeEvent) => {
-      if (e.affectsConfiguration("mesonbuild")) {
+      if (e.affectsConfiguration("mesonbuild.buildFolder")) {
+        // buildFolder is rather ingrained right now, so changes there require a full reload.
+        vscode.commands.executeCommand("workbench.action.reloadWindow");
+      } else if (e.affectsConfiguration("mesonbuild")) {
         changeHandler();
       }
     })


### PR DESCRIPTION
Following on from #134

FWIW. Very sledgehammer / nut. I can't see a trivial and more fine-grained approach (e.g. just deactivate/reactivate extension) and given I want to rebase code that already decouples builddir, I don't really want to look any further. 

That said I did see this: https://github.com/microsoft/vscode/issues/45774#issuecomment-373423895
