### PR TITLE
Add test and benchmark options

### DIFF
--- a/package.json
+++ b/package.json
@@ -125,6 +125,18 @@
           "description": "Specify the list of options used for Meson setup. Can be used to specify a cross file (use --cross-file=FILE).",
           "deprecationMessage": "--cross-file and --native-file should be in configureOptions too."
         },
+        "mesonbuild.testOptions": {
+          "type": "array",
+          "default": [],
+          "description": "Specify the list of options used for running tests."
+        },
+        "mesonbuild.benchmarkOptions": {
+          "type": "array",
+          "default": [
+            "--verbose"
+          ],
+          "description": "Specify the list of options used for running benchmarks. --benchmark is implicit."
+        },
         "mesonbuild.mesonPath": {
           "type": "string",
           "default": "meson",
@@ -304,7 +316,7 @@
         "source": "gcc",
         "owner": "meson",
         "fileLocation": [
-          "autodetect",
+          "autoDetect",
           "${workspaceFolder}/${config:mesonbuild.buildFolder}"
         ],
         "pattern": {

--- a/src/tasks.ts
+++ b/src/tasks.ts
@@ -16,13 +16,14 @@ interface MesonTaskDefinition extends vscode.TaskDefinition {
 }
 
 function createTestTask(t: Test, buildDir: string, isBenchmark: boolean) {
-  const project = t.suite[0].split(":")[0]
+  const project = t.suite[0].split(":")[0];
   const name = `${project}:${t.name}`;
-  const mode = isBenchmark ? "benchmark" : 'test'
-  const benchmarkArgs = isBenchmark ? ["--benchmark", "--verbose"] : [];
-  const args = ["test", ...benchmarkArgs].concat(name);
+  const mode = isBenchmark ? "benchmark" : "test";
+  const benchmarkSwitch = isBenchmark ? ["--benchmark"] : [];
+  const args = ["test", ...benchmarkSwitch, ...extensionConfiguration(`${mode}Options`), name];
+
   const testTask = new vscode.Task(
-    { type: "meson", mode: mode, target: name },
+    { type: "meson", mode, target: name },
     `Test ${name}`,
     "Meson",
     new vscode.ProcessExecution(extensionConfiguration("mesonPath"), args, {
@@ -82,13 +83,13 @@ export async function getMesonTasks(buildDir: string): Promise<vscode.Task[]> {
       { type: "meson", mode: "test" },
       "Run all tests",
       "Meson",
-      new vscode.ProcessExecution(extensionConfiguration("mesonPath"), ["test"], { cwd: buildDir })
+      new vscode.ProcessExecution(extensionConfiguration("mesonPath"), ["test", ...extensionConfiguration("testOptions")], { cwd: buildDir })
     );
     const defaultBenchmarkTask = new vscode.Task(
       { type: "meson", mode: "benchmark" },
       "Run all benchmarks",
       "Meson",
-      new vscode.ProcessExecution(extensionConfiguration("mesonPath"), ["test", "--benchmark", "--verbose"], { cwd: buildDir })
+      new vscode.ProcessExecution(extensionConfiguration("mesonPath"), ["test", "--benchmark", ...extensionConfiguration("benchmarkOptions")], { cwd: buildDir })
     );
     const defaultReconfigureTask = createReconfigureTask(buildDir);
     const defaultInstallTask = new vscode.Task(

--- a/src/types.ts
+++ b/src/types.ts
@@ -12,6 +12,8 @@ export interface ExtensionConfiguration {
   configureOnOpen: boolean | "ask";
   configureOptions: string[];
   setupOptions: string[];
+  testOptions: string[];
+  benchmarkOptions: string[];
   buildFolder: string;
   mesonPath: string;
   muonPath: string;


### PR DESCRIPTION
Being able to run tests with `--verbose` is sometimes useful.

Maybe `testOptions` (and a separate `benchmarkOptions`) is a better more generic approach?
