### PR TITLE
Don't cache failed getMesonTasks() result.

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -68,11 +68,15 @@ export async function activate(ctx: vscode.ExtensionContext) {
   controller.createRunProfile("Meson run test", vscode.TestRunProfileKind.Run, (request, token) => testRunHandler(controller, request, token), true)
   ctx.subscriptions.push(controller);
 
-  let mesonTasks: Thenable<vscode.Task[]> | null = null;
+  let mesonTasks: Promise<vscode.Task[]> | null = null;
   ctx.subscriptions.push(
     vscode.tasks.registerTaskProvider("meson", {
       provideTasks() {
-        mesonTasks ??= getMesonTasks(buildDir);
+        if (mesonTasks == null) {
+          mesonTasks = getMesonTasks(buildDir);
+          mesonTasks.catch(() => mesonTasks = null);
+        }
+
         return mesonTasks;
       },
       resolveTask() {

--- a/src/tasks.ts
+++ b/src/tasks.ts
@@ -172,7 +172,7 @@ export async function getMesonTasks(buildDir: string) {
       "Could not fetch targets. See Meson Build output tab for more info."
     );
 
-    return [];
+    throw e;
   }
 }
 


### PR DESCRIPTION
I don't think it should rely on `changeHandler` being invoked to clear the cache.