### PR TITLE
Don't patch compile_commands.json any more

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -7,7 +7,7 @@ import {
   workspaceRelative,
   extensionConfigurationSet,
   genEnvFile,
-  patchCompileCommands,
+  useCompileCommands,
   clearCache,
   checkMesonIsConfigured
 } from "./utils";
@@ -107,13 +107,13 @@ export async function activate(ctx: vscode.ExtensionContext) {
   );
 
   const compileCommandsHandler = async () => {
-    await patchCompileCommands(buildDir);
+    await useCompileCommands(buildDir);
   };
   compileCommandsWatcher = vscode.workspace.createFileSystemWatcher(`${buildDir}/compile_commands.json`, false, false, true);
   compileCommandsWatcher.onDidChange(compileCommandsHandler);
   compileCommandsWatcher.onDidCreate(compileCommandsHandler);
   ctx.subscriptions.push(compileCommandsWatcher);
-  await patchCompileCommands(buildDir);
+  await useCompileCommands(buildDir);
 
   ctx.subscriptions.push(
     vscode.commands.registerCommand("mesonbuild.openBuildFile", async (node: TargetNode) => {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -163,32 +163,17 @@ export function getEnvDict() {
   return _envDict;
 }
 
-export async function patchCompileCommands(buildDir: string) {
+export async function useCompileCommands(buildDir: string) {
   const filePath = path.join(buildDir, "compile_commands.json");
-  let db = await parseJSONFileIfExists(filePath);
-  if (!db)
-    return;
-
-  // Remove ccache from compile commands because they confuse Intellisense:
-  // https://github.com/microsoft/vscode-cpptools/issues/7616
-  Object.values(db).forEach((entry) => {
-    // FIXME: This should use proper shlex.split() and shlex.join()
-    let cmd = entry["command"].split(" ");
-    if (cmd[0].endsWith("ccache")) {
-      cmd.shift();
-      entry["command"] = cmd.join(" ");
+  if (fs.existsSync(filePath)) {
+    // Since we have compile_commands.json, make sure we use it.
+    try {
+      const relFilePath = path.relative(vscode.workspace.rootPath!, filePath);
+      const conf = vscode.workspace.getConfiguration("C_Cpp");
+      conf.update("default.compileCommands", relFilePath, vscode.ConfigurationTarget.Workspace);
+    } catch {
+        // Ignore, C/C++ extension might not be installed
     }
-  });
-  const vsCodeFilePath = path.join(buildDir, "vscode_compile_commands.json")
-  fs.writeFileSync(vsCodeFilePath, JSON.stringify(db, null, "  "));
-
-  // Since we have compile_commands.json, make sure we use it.
-  try {
-    const relFilePath = path.relative(vscode.workspace.rootPath!, vsCodeFilePath);
-    const conf = vscode.workspace.getConfiguration("C_Cpp");
-    conf.update("default.compileCommands", relFilePath, vscode.ConfigurationTarget.Workspace);
-  } catch {
-      // Ignore, C/C++ extension might not be installed
   }
 }
 


### PR DESCRIPTION
The ccache bug has been fixed upstream:
https://github.com/microsoft/vscode-cpptools/issues/7616