### PR TITLE
tasks: list examples as runnable executables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Add syntax highlight for `meson.options` files.
 - Fix listing tests in the Test Explorer on activation
+- Add support to run executables that are not installed (eg: examples)
 
 ## 1.10.0
 

--- a/src/tasks.ts
+++ b/src/tasks.ts
@@ -152,10 +152,12 @@ export async function getMesonTasks(buildDir: string) {
               "$meson-gcc",
             );
             buildTask.group = vscode.TaskGroup.Build;
-            // FIXME: We should only include executable installed in bindir,
-            // but install_dir is missing from intro data.
-            if (t.type == "executable" && t.installed) {
-              return [buildTask, createRunTask(t, targetName)];
+            if (t.type == "executable") {
+              // Create run tasks for executables that are not tests,
+              // both installed and uninstalled (eg: examples)
+              if (!tests.some((test) => test.name === t.name)) {
+                return [buildTask, createRunTask(t, targetName)];
+              }
             }
             return buildTask;
           }),


### PR DESCRIPTION
The list of runnable executables excludes not installed executables to filter out tests, but this also filters out other executables like examples. Instead, cross-chech with the tests array to remove only tests