### PR TITLE
List tests on activation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## next
 
 - Add syntax highlight for `meson.options` files.
+- Fix listing tests in the Test Explorer on activation
 
 ## 1.10.0
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -96,6 +96,7 @@ export async function activate(ctx: vscode.ExtensionContext) {
   watcher.onDidChange(changeHandler);
   watcher.onDidCreate(changeHandler);
   ctx.subscriptions.push(watcher);
+  await rebuildTests(controller);
   await genEnvFile(buildDir);
 
   // Refresh if the extension configuration is changed.


### PR DESCRIPTION
 The tests list in the tests controller is only updated when a change is detected. It's now done on activation  to list all tests from the beginning.