### PR TITLE
Add support for CodeLLDB extension

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## next
 
+- Add support for CodeLLDB extension
+
 ## 1.12.1
 
 - Fix [#155](https://github.com/mesonbuild/vscode-meson/issues/155)

--- a/package.json
+++ b/package.json
@@ -41,7 +41,8 @@
   "activationEvents": [
     "workspaceContains:meson.build",
     "onDebugDynamicConfigurations",
-    "onDebugDynamicConfigurations:cppdbg"
+    "onDebugDynamicConfigurations:cppdbg",
+    "onDebugDynamicConfigurations:lldb"
   ],
   "main": "./out/extension",
   "contributes": {

--- a/src/configprovider-cppdbg.ts
+++ b/src/configprovider-cppdbg.ts
@@ -2,11 +2,6 @@ import * as vscode from "vscode";
 import { Target } from "./types";
 import { MesonDebugConfigurationProvider } from "./configprovider";
 
-export enum MIModes {
-  lldb = "lldb",
-  gdb = "gdb",
-}
-
 export class DebugConfigurationProviderCppdbg extends MesonDebugConfigurationProvider {
   constructor(path: string) {
     super(path);
@@ -30,7 +25,7 @@ export class DebugConfigurationProviderCppdbg extends MesonDebugConfigurationPro
 
   async createGDBDebugConfiguration(target: Target): Promise<vscode.DebugConfiguration> {
     let debugConfig = await super.createDebugConfiguration(target);
-    debugConfig["MIMode"] = MIModes.gdb;
+    debugConfig["MIMode"] = "gdb";
     debugConfig["setupCommands"] = [
       {
         description: "Enable pretty-printing for gdb",
@@ -43,7 +38,7 @@ export class DebugConfigurationProviderCppdbg extends MesonDebugConfigurationPro
 
   async createLLDBDebugConfiguration(target: Target): Promise<vscode.DebugConfiguration> {
     let debugConfig = await super.createDebugConfiguration(target);
-    debugConfig["MIMode"] = MIModes.lldb;
+    debugConfig["MIMode"] = "lldb";
     return debugConfig;
   }
 

--- a/src/configprovider-cppdbg.ts
+++ b/src/configprovider-cppdbg.ts
@@ -10,6 +10,8 @@ export enum MIModes {
 }
 
 export class DebugConfigurationProviderCppdbg implements vscode.DebugConfigurationProvider {
+  static readonly type = "cppdbg";
+
   private path: string;
 
   constructor(path: string) {
@@ -19,7 +21,7 @@ export class DebugConfigurationProviderCppdbg implements vscode.DebugConfigurati
   async createBaseDebugConfiguration(target: Target): Promise<vscode.DebugConfiguration> {
     const targetName = await getTargetName(target);
     return {
-      type: "cppdbg",
+      type: DebugConfigurationProviderCppdbg.type,
       name: `Debug ${target.name} (cppdbg)`,
       request: "launch",
       cwd: path.dirname(this.path),

--- a/src/configprovider-cppdbg.ts
+++ b/src/configprovider-cppdbg.ts
@@ -9,7 +9,7 @@ export enum MIModes {
   gdb = "gdb",
 }
 
-export class DebugConfigurationProvider implements vscode.DebugConfigurationProvider {
+export class DebugConfigurationProviderCppdbg implements vscode.DebugConfigurationProvider {
   private path: string;
 
   constructor(path: string) {
@@ -20,7 +20,7 @@ export class DebugConfigurationProvider implements vscode.DebugConfigurationProv
     const targetName = await getTargetName(target);
     return {
       type: "cppdbg",
-      name: `Debug ${target.name}`,
+      name: `Debug ${target.name} (cppdbg)`,
       request: "launch",
       cwd: path.dirname(this.path),
       program: target.filename[0],

--- a/src/configprovider-lldb.ts
+++ b/src/configprovider-lldb.ts
@@ -1,67 +1,11 @@
-import * as vscode from "vscode";
-import * as path from "path";
-import { getMesonTargets } from "./introspection";
-import { Target } from "./types";
-import { extensionConfiguration, getTargetName } from "./utils";
+import { MesonDebugConfigurationProvider } from "./configprovider";
 
-export class DebugConfigurationProviderLldb implements vscode.DebugConfigurationProvider {
-  static readonly type = "lldb";
-
-  private path: string;
-
+export class DebugConfigurationProviderLldb extends MesonDebugConfigurationProvider {
   constructor(path: string) {
-    this.path = path;
+    super(path);
   }
 
-  async createDebugConfiguration(target: Target): Promise<vscode.DebugConfiguration> {
-    const targetName = await getTargetName(target);
-    return {
-      type: DebugConfigurationProviderLldb.type,
-      name: `Debug ${target.name} (lldb)`,
-      request: "launch",
-      cwd: path.dirname(this.path),
-      program: target.filename[0],
-      args: [],
-      preLaunchTask: `Meson: Build ${targetName}`,
-    };
-  }
-
-  async provideDebugConfigurations(
-    folder: vscode.WorkspaceFolder | undefined,
-    token?: vscode.CancellationToken,
-  ): Promise<vscode.DebugConfiguration[]> {
-    let targets = await getMesonTargets(this.path);
-
-    let configDebugOptions = extensionConfiguration("debugOptions");
-
-    const executables = targets.filter((target) => target.type == "executable");
-    let ret: vscode.DebugConfiguration[] = [];
-
-    for (const target of executables) {
-      if (!target.target_sources?.some((source) => ["cpp", "c"].includes(source.language))) {
-        continue;
-      }
-
-      let debugConfiguration = await this.createDebugConfiguration(target);
-      ret.push({ ...configDebugOptions, ...debugConfiguration });
-    }
-
-    return ret;
-  }
-
-  resolveDebugConfiguration(
-    folder: vscode.WorkspaceFolder | undefined,
-    debugConfiguration: vscode.DebugConfiguration,
-    token?: vscode.CancellationToken,
-  ): vscode.ProviderResult<vscode.DebugConfiguration> {
-    return debugConfiguration;
-  }
-
-  resolveDebugConfigurationWithSubstitutedVariables(
-    folder: vscode.WorkspaceFolder,
-    debugConfiguration: vscode.DebugConfiguration,
-    token?: vscode.CancellationToken,
-  ): vscode.ProviderResult<vscode.DebugConfiguration> {
-    return debugConfiguration;
+  override getName(): string {
+    return "lldb";
   }
 }

--- a/src/configprovider-lldb.ts
+++ b/src/configprovider-lldb.ts
@@ -1,0 +1,65 @@
+import * as vscode from "vscode";
+import * as path from "path";
+import { getMesonTargets } from "./introspection";
+import { Target } from "./types";
+import { extensionConfiguration, getTargetName } from "./utils";
+
+export class DebugConfigurationProviderLldb implements vscode.DebugConfigurationProvider {
+  private path: string;
+
+  constructor(path: string) {
+    this.path = path;
+  }
+
+  async createDebugConfiguration(target: Target): Promise<vscode.DebugConfiguration> {
+    const targetName = await getTargetName(target);
+    return {
+      type: "lldb",
+      name: `Debug ${target.name} (lldb)`,
+      request: "launch",
+      cwd: path.dirname(this.path),
+      program: target.filename[0],
+      args: [],
+      preLaunchTask: `Meson: Build ${targetName}`,
+    };
+  }
+
+  async provideDebugConfigurations(
+    folder: vscode.WorkspaceFolder | undefined,
+    token?: vscode.CancellationToken,
+  ): Promise<vscode.DebugConfiguration[]> {
+    let targets = await getMesonTargets(this.path);
+
+    let configDebugOptions = extensionConfiguration("debugOptions");
+
+    const executables = targets.filter((target) => target.type == "executable");
+    let ret: vscode.DebugConfiguration[] = [];
+
+    for (const target of executables) {
+      if (!target.target_sources?.some((source) => ["cpp", "c"].includes(source.language))) {
+        continue;
+      }
+
+      let debugConfiguration = await this.createDebugConfiguration(target);
+      ret.push({ ...configDebugOptions, ...debugConfiguration });
+    }
+
+    return ret;
+  }
+
+  resolveDebugConfiguration(
+    folder: vscode.WorkspaceFolder | undefined,
+    debugConfiguration: vscode.DebugConfiguration,
+    token?: vscode.CancellationToken,
+  ): vscode.ProviderResult<vscode.DebugConfiguration> {
+    return debugConfiguration;
+  }
+
+  resolveDebugConfigurationWithSubstitutedVariables(
+    folder: vscode.WorkspaceFolder,
+    debugConfiguration: vscode.DebugConfiguration,
+    token?: vscode.CancellationToken,
+  ): vscode.ProviderResult<vscode.DebugConfiguration> {
+    return debugConfiguration;
+  }
+}

--- a/src/configprovider-lldb.ts
+++ b/src/configprovider-lldb.ts
@@ -5,6 +5,8 @@ import { Target } from "./types";
 import { extensionConfiguration, getTargetName } from "./utils";
 
 export class DebugConfigurationProviderLldb implements vscode.DebugConfigurationProvider {
+  static readonly type = "lldb";
+
   private path: string;
 
   constructor(path: string) {
@@ -14,7 +16,7 @@ export class DebugConfigurationProviderLldb implements vscode.DebugConfiguration
   async createDebugConfiguration(target: Target): Promise<vscode.DebugConfiguration> {
     const targetName = await getTargetName(target);
     return {
-      type: "lldb",
+      type: DebugConfigurationProviderLldb.type,
       name: `Debug ${target.name} (lldb)`,
       request: "launch",
       cwd: path.dirname(this.path),

--- a/src/configprovider.ts
+++ b/src/configprovider.ts
@@ -1,0 +1,68 @@
+import * as vscode from "vscode";
+import * as path from "path";
+import { getMesonTargets } from "./introspection";
+import { Target } from "./types";
+import { extensionConfiguration, getTargetName } from "./utils";
+
+export abstract class MesonDebugConfigurationProvider implements vscode.DebugConfigurationProvider {
+  private readonly path: string;
+
+  constructor(path: string) {
+    this.path = path;
+  }
+
+  abstract getName(): string;
+
+  async createDebugConfiguration(target: Target): Promise<vscode.DebugConfiguration> {
+    const targetName = await getTargetName(target);
+    const name = this.getName();
+    return {
+      type: name,
+      name: `Debug ${target.name} (${name})`,
+      request: "launch",
+      cwd: path.dirname(this.path),
+      program: target.filename[0],
+      args: [],
+      preLaunchTask: `Meson: Build ${targetName}`,
+    };
+  }
+
+  async provideDebugConfigurations(
+    folder: vscode.WorkspaceFolder | undefined,
+    token?: vscode.CancellationToken,
+  ): Promise<vscode.DebugConfiguration[]> {
+    const targets = await getMesonTargets(this.path);
+
+    const configDebugOptions = extensionConfiguration("debugOptions");
+
+    const executables = targets.filter((target) => target.type == "executable");
+    let ret: vscode.DebugConfiguration[] = [];
+
+    for (const target of executables) {
+      if (!target.target_sources?.some((source) => ["cpp", "c"].includes(source.language))) {
+        continue;
+      }
+
+      const debugConfiguration = await this.createDebugConfiguration(target);
+      ret.push({ ...configDebugOptions, ...debugConfiguration });
+    }
+
+    return ret;
+  }
+
+  resolveDebugConfiguration(
+    folder: vscode.WorkspaceFolder | undefined,
+    debugConfiguration: vscode.DebugConfiguration,
+    token?: vscode.CancellationToken,
+  ): vscode.ProviderResult<vscode.DebugConfiguration> {
+    return debugConfiguration;
+  }
+
+  resolveDebugConfigurationWithSubstitutedVariables(
+    folder: vscode.WorkspaceFolder,
+    debugConfiguration: vscode.DebugConfiguration,
+    token?: vscode.CancellationToken,
+  ): vscode.ProviderResult<vscode.DebugConfiguration> {
+    return debugConfiguration;
+  }
+}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -13,6 +13,7 @@ import {
   getOutputChannel,
 } from "./utils";
 import { DebugConfigurationProviderCppdbg } from "./configprovider-cppdbg";
+import { DebugConfigurationProviderLldb } from "./configprovider-lldb";
 import { testDebugHandler, testRunHandler, rebuildTests } from "./tests";
 import { activateLinters } from "./linters";
 import { activateFormatters } from "./formatters";
@@ -42,6 +43,14 @@ export async function activate(ctx: vscode.ExtensionContext) {
     vscode.debug.registerDebugConfigurationProvider(
       "cppdbg",
       new DebugConfigurationProviderCppdbg(buildDir),
+      vscode.DebugConfigurationProviderTriggerKind.Dynamic,
+    ),
+  );
+
+  ctx.subscriptions.push(
+    vscode.debug.registerDebugConfigurationProvider(
+      "lldb",
+      new DebugConfigurationProviderLldb(buildDir),
       vscode.DebugConfigurationProviderTriggerKind.Dynamic,
     ),
   );

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -39,21 +39,17 @@ export async function activate(ctx: vscode.ExtensionContext) {
 
   explorer = new MesonProjectExplorer(ctx, root, buildDir);
 
-  ctx.subscriptions.push(
-    vscode.debug.registerDebugConfigurationProvider(
-      DebugConfigurationProviderCppdbg.type,
-      new DebugConfigurationProviderCppdbg(buildDir),
-      vscode.DebugConfigurationProviderTriggerKind.Dynamic,
-    ),
-  );
-
-  ctx.subscriptions.push(
-    vscode.debug.registerDebugConfigurationProvider(
-      DebugConfigurationProviderLldb.type,
-      new DebugConfigurationProviderLldb(buildDir),
-      vscode.DebugConfigurationProviderTriggerKind.Dynamic,
-    ),
-  );
+  const providers = [DebugConfigurationProviderCppdbg, DebugConfigurationProviderLldb];
+  providers.forEach((provider) => {
+    const p = new provider(buildDir);
+    ctx.subscriptions.push(
+      vscode.debug.registerDebugConfigurationProvider(
+        p.getName(),
+        p,
+        vscode.DebugConfigurationProviderTriggerKind.Dynamic,
+      ),
+    );
+  });
 
   const updateHasProject = async () => {
     const mesonFiles = await vscode.workspace.findFiles("**/meson.build");

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -41,7 +41,7 @@ export async function activate(ctx: vscode.ExtensionContext) {
 
   ctx.subscriptions.push(
     vscode.debug.registerDebugConfigurationProvider(
-      "cppdbg",
+      DebugConfigurationProviderCppdbg.type,
       new DebugConfigurationProviderCppdbg(buildDir),
       vscode.DebugConfigurationProviderTriggerKind.Dynamic,
     ),
@@ -49,7 +49,7 @@ export async function activate(ctx: vscode.ExtensionContext) {
 
   ctx.subscriptions.push(
     vscode.debug.registerDebugConfigurationProvider(
-      "lldb",
+      DebugConfigurationProviderLldb.type,
       new DebugConfigurationProviderLldb(buildDir),
       vscode.DebugConfigurationProviderTriggerKind.Dynamic,
     ),

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -12,7 +12,7 @@ import {
   checkMesonIsConfigured,
   getOutputChannel,
 } from "./utils";
-import { DebugConfigurationProvider } from "./configprovider";
+import { DebugConfigurationProviderCppdbg } from "./configprovider-cppdbg";
 import { testDebugHandler, testRunHandler, rebuildTests } from "./tests";
 import { activateLinters } from "./linters";
 import { activateFormatters } from "./formatters";
@@ -41,7 +41,7 @@ export async function activate(ctx: vscode.ExtensionContext) {
   ctx.subscriptions.push(
     vscode.debug.registerDebugConfigurationProvider(
       "cppdbg",
-      new DebugConfigurationProvider(buildDir),
+      new DebugConfigurationProviderCppdbg(buildDir),
       vscode.DebugConfigurationProviderTriggerKind.Dynamic,
     ),
   );

--- a/src/tests.ts
+++ b/src/tests.ts
@@ -99,6 +99,24 @@ export async function testDebugHandler(
     return;
   }
 
+  let debugType = null;
+
+  const cppTools = vscode.extensions.getExtension("ms-vscode.cpptools");
+  if (cppTools && cppTools.isActive) {
+    debugType = "cppdbg";
+  } else {
+    const codelldb = vscode.extensions.getExtension("vadimcn.vscode-lldb");
+    if (codelldb && codelldb.isActive) {
+      debugType = "lldb";
+    }
+  }
+
+  if (!debugType) {
+    vscode.window.showErrorMessage("No debugger extension found. Please install one and try again");
+    run.end();
+    return;
+  }
+
   let configDebugOptions = extensionConfiguration("debugOptions");
 
   /* We already figured out which tests we want to run.
@@ -109,7 +127,7 @@ export async function testDebugHandler(
 
     let debugConfiguration = {
       name: `meson-debug-${test.name}`,
-      type: "cppdbg",
+      type: debugType,
       request: "launch",
       cwd: test.workdir || workspaceRelative(extensionConfiguration("buildFolder")),
       env: test.env,


### PR DESCRIPTION
Currently, the vscode-meson extension is hardcoded to support only Microsoft's C/C++ extension, which provides the `cppdbg` debugger. However, using the Microsoft extension may not be preferable. An alternative extension, CodeLLDB (https://github.com/vadimcn/codelldb), also provides C/C++ support, including the `lldb` debugger.

These changes add a second debug configuration provider that works with the `lldb` debugger.

These changes also introduce an extension availability check when trying to run tests with debugging. Both the `cppdbg` and `lldb` debuggers are supported, in that order. In addition, a proper error message is now displayed instead of the cryptic "Configured debug type 'cppdbg' is not supported" when no debuggers are available.

Note: The `lldb` debug configuration sets the working directory to `path.dirname(this.path)`, which translates to the parent directory of the build root. This matches the `cppdbg` debug configuration. However, the tests debug configuration falls back to `workspaceRelative(extensionConfiguration("buildFolder")`. Shouldn't this be the same?