### PR TITLE
Add auto-updater for Swift-MesonLSP

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## next
 
 - Add configuration options specific for Swift-MesonLSP.
+- Add auto-updater for Swift-MesonLSP.
 
 ## 1.13.0
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -253,6 +253,8 @@ export async function activate(ctx: vscode.ExtensionContext) {
         }
       }),
     );
+
+    await client.update(ctx);
     ctx.subscriptions.push(client);
     client.start();
     await client.reloadConfig();

--- a/src/lsp/common.ts
+++ b/src/lsp/common.ts
@@ -4,20 +4,20 @@ import { LanguageServer } from "../types";
 import { SwiftMesonLspLanguageClient } from "./swift-mesonlsp";
 import { Uri } from "vscode";
 
+export function serverToClass(server: LanguageServer): any {
+  switch (server) {
+    case "Swift-MesonLSP":
+      return SwiftMesonLspLanguageClient;
+    default:
+      return null;
+  }
+}
+
 export async function createLanguageServerClient(
   server: LanguageServer,
   download: boolean,
   context: vscode.ExtensionContext,
 ): Promise<LanguageServerClient | null> {
-  const serverToClass = (server: LanguageServer) => {
-    switch (server) {
-      case "Swift-MesonLSP":
-        return SwiftMesonLspLanguageClient;
-      default:
-        return null;
-    }
-  };
-
   const klass = serverToClass(server);
   if (klass == null) {
     return null;
@@ -54,5 +54,5 @@ export async function createLanguageServerClient(
     }
   }
 
-  return new klass(languageServerPath, context);
+  return new klass(languageServerPath, context, klass.version);
 }

--- a/src/lsp/swift-mesonlsp.ts
+++ b/src/lsp/swift-mesonlsp.ts
@@ -38,8 +38,8 @@ export class SwiftMesonLspLanguageClient extends LanguageServerClient {
     };
   }
 
-  constructor(languageServerPath: vscode.Uri, context: vscode.ExtensionContext) {
-    super("Swift-MesonLSP", languageServerPath, context);
+  constructor(languageServerPath: vscode.Uri, context: vscode.ExtensionContext, referenceVersion: string) {
+    super("Swift-MesonLSP", languageServerPath, context, referenceVersion);
   }
 
   static override artifact(): { url: string; hash: string } | null {


### PR DESCRIPTION
This is using a simpler thing for auto-updates. It couples the Swift-MesonLSP version to the vscode-meson version.  (Somewhat based on https://github.com/mesonbuild/vscode-meson/issues/119#issuecomment-1560059245 and the previous comments). This makes sense as it seems like you do a lot of smaller releases.

For testing, you can edit the file: `~/.config/VSCodium/User/globalStorage/mesonbuild.mesonbuild/lsp/version` to e.g. 1.2.3 and then run VSCode. It should automatically update to 2.4..4.

