### PR TITLE
Send configuration fo mesonbuild to language server, if it changed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## next
 
+- Add configuration options specific for Swift-MesonLSP.
+
 ## 1.13.0
 
 - Add support for CodeLLDB extension


### PR DESCRIPTION
Configuration format is like this in your .settings.json
```
{
    "mesonbuild.Swift-MesonLSP": {
        "others": {
            "ignoreDiagnosticsFromSubprojects": true,
        },
        "linting": {
            "disableNameLinting": true,
            "disableCompilerIdLinting": true,
        }
    }
}
```

Testing:
- Remove downloaded language server from the vscode extension
- Use binaries from HEAD of https://github.com/JCWasmx86/Swift-MesonLSP and drop them in PATH
- Use e.g. https://github.com/hse-project/hse

Your diagnostics will look like this:
![image](https://github.com/mesonbuild/vscode-meson/assets/63594136/a77ee323-4d98-481f-b27c-f6bac962cb98)

Merge the config listed above with your .settings.json.

Only this error will be left:
![image](https://github.com/mesonbuild/vscode-meson/assets/63594136/39d3023c-d232-402c-beb7-c4c6206e54cc)


(A bug on my side, as my heuristics will never be able to guess the sophisticated subdir calculation for hse-python, but that's offtopic here)

Only thing missing here is the auto-completion/diagnostics in the settings.json file.