### PR TITLE
Enable storage of meson.build in a non-root directory in the workspace

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "Programming Languages"
   ],
   "activationEvents": [
-    "workspaceContains:meson.build",
+    "workspaceContains:**/meson.build",
     "onDebugDynamicConfigurations",
     "onDebugDynamicConfigurations:cppdbg",
     "onDebugDynamicConfigurations:lldb"

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -47,6 +47,7 @@ export async function activate(ctx: vscode.ExtensionContext) {
   const buildDir = relativeBuildDir(mesonFile.fsPath);
 
   workspaceState.update("mesonbuild.buildDir", buildDir);
+  workspaceState.update("mesonbuild.sourceDir", sourceDir);
 
   explorer = new MesonProjectExplorer(ctx, root, buildDir);
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -207,6 +207,10 @@ export async function activate(ctx: vscode.ExtensionContext) {
           break;
       }
     }
+
+    if (configureOnOpen) {
+      runFirstTask("reconfigure");
+    }
   } else {
     await rebuildTests(controller);
   }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -21,6 +21,7 @@ import { SettingsKey, TaskQuickPickItem } from "./types";
 import { createLanguageServerClient } from "./lsp/common";
 
 export let extensionPath: string;
+export let workspaceState: vscode.Memento;
 let explorer: MesonProjectExplorer;
 let watcher: vscode.FileSystemWatcher;
 let compileCommandsWatcher: vscode.FileSystemWatcher;
@@ -29,6 +30,7 @@ let controller: vscode.TestController;
 
 export async function activate(ctx: vscode.ExtensionContext) {
   extensionPath = ctx.extensionPath;
+  workspaceState = ctx.workspaceState;
 
   if (!vscode.workspace.workspaceFolders) {
     return;
@@ -36,6 +38,8 @@ export async function activate(ctx: vscode.ExtensionContext) {
 
   const root = vscode.workspace.workspaceFolders[0].uri.fsPath;
   const buildDir = workspaceRelative(extensionConfiguration("buildFolder"));
+
+  workspaceState.update("mesonbuild.buildDir", buildDir);
 
   explorer = new MesonProjectExplorer(ctx, root, buildDir);
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -4,13 +4,13 @@ import { MesonProjectExplorer } from "./treeview";
 import { TargetNode } from "./treeview/nodes/targets";
 import {
   extensionConfiguration,
-  workspaceRelative,
   extensionConfigurationSet,
   genEnvFile,
   useCompileCommands,
   clearCache,
   checkMesonIsConfigured,
   getOutputChannel,
+  relativeBuildDir,
 } from "./utils";
 import { DebugConfigurationProviderCppdbg } from "./debug/cppdbg";
 import { DebugConfigurationProviderLldb } from "./debug/lldb";
@@ -19,6 +19,7 @@ import { activateLinters } from "./linters";
 import { activateFormatters } from "./formatters";
 import { SettingsKey, TaskQuickPickItem } from "./types";
 import { createLanguageServerClient } from "./lsp/common";
+import { dirname } from "path";
 
 export let extensionPath: string;
 export let workspaceState: vscode.Memento;
@@ -37,7 +38,12 @@ export async function activate(ctx: vscode.ExtensionContext) {
   }
 
   const root = vscode.workspace.workspaceFolders[0].uri.fsPath;
-  const buildDir = workspaceRelative(extensionConfiguration("buildFolder"));
+  const mesonFiles = await vscode.workspace.findFiles("**/meson.build");
+  if (mesonFiles.length === 0) {
+    return;
+  }
+  const mesonFile = mesonFiles[0];
+  const buildDir = relativeBuildDir(mesonFile.fsPath);
 
   workspaceState.update("mesonbuild.buildDir", buildDir);
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -235,6 +235,7 @@ export async function activate(ctx: vscode.ExtensionContext) {
     }
 
     if (configureOnOpen) {
+      let cancel = false;
       if (!configurationChosen && mesonFiles.length > 1) {
         const items = mesonFiles.map((file, index) => ({ index: index, label: relative(root, file.fsPath) }));
         items.sort((a, b) => a.label.localeCompare(b.label));
@@ -248,8 +249,11 @@ export async function activate(ctx: vscode.ExtensionContext) {
           await workspaceState.update("mesonbuild.configurationChosen", true);
           vscode.commands.executeCommand("workbench.action.reloadWindow");
         }
+        cancel = selection === undefined;
       }
-      runFirstTask("reconfigure");
+      if (!cancel) {
+        runFirstTask("reconfigure");
+      }
     }
   } else {
     await rebuildTests(controller);

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -43,6 +43,7 @@ export async function activate(ctx: vscode.ExtensionContext) {
     return;
   }
   const mesonFile = mesonFiles[0];
+  const sourceDir = dirname(mesonFile.fsPath);
   const buildDir = relativeBuildDir(mesonFile.fsPath);
 
   workspaceState.update("mesonbuild.buildDir", buildDir);
@@ -86,7 +87,7 @@ export async function activate(ctx: vscode.ExtensionContext) {
   ctx.subscriptions.push(
     vscode.tasks.registerTaskProvider("meson", {
       provideTasks() {
-        mesonTasks ??= getMesonTasks(buildDir);
+        mesonTasks ??= getMesonTasks(buildDir, sourceDir);
         return mesonTasks;
       },
       resolveTask() {

--- a/src/tasks.ts
+++ b/src/tasks.ts
@@ -51,21 +51,20 @@ function createRunTask(t: Target, targetName: string) {
   return runTask;
 }
 
-function createReconfigureTask(buildDir: string) {
+function createReconfigureTask(buildDir: string, sourceDir: string) {
   const configureOpts = extensionConfiguration("configureOptions");
   const setupOpts = extensionConfiguration("setupOptions");
   const reconfigureOpts = checkMesonIsConfigured(buildDir) ? ["--reconfigure"] : [];
-  const args = ["setup", ...reconfigureOpts, ...configureOpts, ...setupOpts, buildDir];
+  const args = ["setup", ...reconfigureOpts, ...configureOpts, ...setupOpts, buildDir, sourceDir];
   return new vscode.Task(
     { type: "meson", mode: "reconfigure" },
     "Reconfigure",
     "Meson",
-    // Note "setup --reconfigure" needs to be run from the root.
-    new vscode.ProcessExecution(extensionConfiguration("mesonPath"), args, { cwd: vscode.workspace.rootPath }),
+    new vscode.ProcessExecution(extensionConfiguration("mesonPath"), args),
   );
 }
 
-export async function getMesonTasks(buildDir: string) {
+export async function getMesonTasks(buildDir: string, sourceDir: string) {
   try {
     const defaultBuildTask = new vscode.Task(
       { type: "meson", mode: "build" },
@@ -94,7 +93,7 @@ export async function getMesonTasks(buildDir: string) {
         { cwd: buildDir },
       ),
     );
-    const defaultReconfigureTask = createReconfigureTask(buildDir);
+    const defaultReconfigureTask = createReconfigureTask(buildDir, sourceDir);
     const defaultInstallTask = new vscode.Task(
       { type: "meson", mode: "install" },
       "Run install",

--- a/src/tasks.ts
+++ b/src/tasks.ts
@@ -3,6 +3,7 @@ import { getMesonTargets, getMesonTests, getMesonBenchmarks } from "./introspect
 import { extensionConfiguration, getOutputChannel, getTargetName, getEnvDict } from "./utils";
 import { Test, Target } from "./types";
 import { checkMesonIsConfigured } from "./utils";
+import { workspaceState } from "./extension";
 
 interface MesonTaskDefinition extends vscode.TaskDefinition {
   type: "meson";
@@ -43,7 +44,7 @@ function createRunTask(t: Target, targetName: string) {
     `Run ${targetDisplayName}`,
     "Meson",
     new vscode.ProcessExecution(t.filename[0], {
-      cwd: vscode.workspace.rootPath,
+      cwd: workspaceState.get<string>("mesonbuild.sourceDir")!,
       env: getEnvDict(),
     }),
   );

--- a/src/tests.ts
+++ b/src/tests.ts
@@ -115,7 +115,8 @@ export async function testDebugHandler(
     return;
   }
 
-  let configDebugOptions = extensionConfiguration("debugOptions");
+  const configDebugOptions = extensionConfiguration("debugOptions");
+  const sourceDir = workspaceState.get<string>("mesonbuild.sourceDir")!;
 
   /* We already figured out which tests we want to run.
    * We don't use the actual test either way, as we don't get the result here... */
@@ -127,7 +128,7 @@ export async function testDebugHandler(
       name: `meson-debug-${test.name}`,
       type: debugType,
       request: "launch",
-      cwd: test.workdir || buildDir,
+      cwd: test.workdir || sourceDir,
       env: test.env,
       program: test.cmd[0],
       args: args,

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -5,7 +5,7 @@ import * as vscode from "vscode";
 import { createHash, BinaryLike } from "crypto";
 import { ExtensionConfiguration, Target } from "./types";
 import { getMesonBuildOptions } from "./introspection";
-import { extensionPath } from "./extension";
+import { extensionPath, workspaceState } from "./extension";
 
 export interface ExecResult {
   stdout: string;
@@ -57,14 +57,10 @@ export function extensionRelative(filepath: string) {
   return path.join(extensionPath, filepath);
 }
 
-export function workspaceRelative(filepath: string) {
-  return path.resolve(vscode.workspace.rootPath!, filepath);
-}
-
 let _layoutPromise: Promise<string> | null = null;
 
 async function getLayout() {
-  const buildDir = workspaceRelative(extensionConfiguration("buildFolder"));
+  const buildDir = workspaceState.get<string>("mesonbuild.buildDir")!;
   const buildOptions = await getMesonBuildOptions(buildDir);
   return buildOptions.filter((o) => o.name === "layout")[0].value;
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -79,11 +79,14 @@ export async function getTargetName(target: Target) {
   const layout = await _layoutPromise;
 
   if (layout === "mirror") {
-    let relativePath = path.relative(vscode.workspace.rootPath!, path.dirname(target.defined_in));
+    const relativePath = path.relative(
+      workspaceState.get<string>("mesonbuild.sourceDir")!,
+      path.dirname(target.defined_in),
+    );
 
     // Meson requires the separator between path and target name to be '/'.
-    relativePath = path.join(relativePath, target.name);
-    const p = relativePath.split(path.sep).join(path.posix.sep);
+    const targetRelativePath = path.join(relativePath, target.name);
+    const p = targetRelativePath.split(path.sep).join(path.posix.sep);
     return `${p}:${target.type.replace(" ", "_")}`;
   } else {
     return `meson-out/${target.name}`;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -57,6 +57,11 @@ export function extensionRelative(filepath: string) {
   return path.join(extensionPath, filepath);
 }
 
+export function relativeBuildDir(mesonFile: string) {
+  const buildDir = extensionConfiguration("buildFolder");
+  return path.join(path.dirname(mesonFile), buildDir);
+}
+
 let _layoutPromise: Promise<string> | null = null;
 
 async function getLayout() {


### PR DESCRIPTION
This PR allows the `meson.build` file to be placed in a subdirectory within the workspace.

The current behavior of the extension is inconsequential, as some checks already look for `meson.build` in the entire workspace, and the activation event fires when you manually open `meson.build` that is stored in a subdirectory, resulting in a prompt to configure the workspace. Of course, there's no support for such behavior within the extension, so things fail.

This is similar to #22, but works automatically. No user-facing configuration option is exposed. If multiple `meson.build` files are found in the workspace, the 'first' one is used. I plan to extend this to allow the user to switch between different `meson.build` configurations within the same workspace, but this PR is a prerequisite for those future changes.

This PR also fixes a regression introduced in 60dc5f7333c893d8c1715a39f6dcc126d35139ea. This commit removed the "configure on open" condition, rendering the reconfigure prompt completely useless and severely degrading the new user experience. The PR restores the removed condition.

In an effort to make things more robust, multiple recalculations of the build directory in different parts of the code have been replaced by a single calculation on extension activation, which is then stored as a workspace-relative memento that can be referenced when needed.

To make things consistent, the working directory provided by debug configurations and when running tests is now set to the "source directory" in the `meson setup` understanding, i.e. the directory where the `meson.build` file resides.

There are two places in the code where `vscode.workspace.rootPath` is still used instead of the source directory. I can't check if this is valid or not.

1. Attempting to explore the targets in the Meson section of the activity bar fails with a `s.sources is not iterable (cannot read property undefined)` error message. This also happens in the currently deployed extension.

2. The `useCompileCommands` function provides data for Microsoft's C++ extension, which I am not interested in. The alternative clangd extension can use the same functionality with the `compile_commands.json` file, and properly providing it for clangd would also show how to do it for Microsoft's extension. But there's another can of worms to tackle to even try to do anything with it (https://mastodon.gamedev.place/@wolfpld/111346306341679920).