### PR TITLE
Fix target source tree view.

### DIFF
--- a/src/treeview/nodes/targets.ts
+++ b/src/treeview/nodes/targets.ts
@@ -91,8 +91,13 @@ export class TargetNode extends BaseNode {
       const sources = new Array<string>();
       const generated_sources = new Array<string>();
       for (const s of this.target.target_sources) {
-        sources.push(...s.sources);
-        sources.push(...s.generated_sources);
+        if ("sources" in s) {
+          sources.push(...s.sources);
+        }
+
+        if ("generated_sources" in s) {
+          sources.push(...s.generated_sources);
+        }
       }
 
       const sourceNode = new TargetSourcesRootNode(this.id, path.dirname(this.target.defined_in), sources);


### PR DESCRIPTION
Due to https://github.com/mesonbuild/meson/commit/5eb55075.

I guess `types.ts` should be updated, but this at least gets the view working again.

