### PR TITLE
Refactor support for multiple Meson projects

### DIFF
--- a/package.json
+++ b/package.json
@@ -405,6 +405,38 @@
         {
           "command": "mesonbuild.openBuildFile",
           "when": "false"
+        },
+        {
+          "command": "mesonbuild.reconfigure",
+          "when": "mesonbuild.hasProject"
+        },
+        {
+          "command": "mesonbuild.clean",
+          "when": "mesonbuild.hasProject"
+        },
+        {
+          "command": "mesonbuild.build",
+          "when": "mesonbuild.hasProject"
+        },
+        {
+          "command": "mesonbuild.test",
+          "when": "mesonbuild.hasProject"
+        },
+        {
+          "command": "mesonbuild.run",
+          "when": "mesonbuild.hasProject"
+        },
+        {
+          "command": "mesonbuild.install",
+          "when": "mesonbuild.hasProject"
+        },
+        {
+          "command": "mesonbuild.benchmark",
+          "when": "mesonbuild.hasProject"
+        },
+        {
+          "command": "mesonbuild.restartLanguageServer",
+          "when": "mesonbuild.hasProject"
         }
       ]
     },

--- a/package.json
+++ b/package.json
@@ -87,11 +87,20 @@
       {
         "command": "mesonbuild.restartLanguageServer",
         "title": "Meson: Restart Language Server"
+      },
+      {
+        "command": "mesonbuild.selectRootDir",
+        "title": "Meson: Select Project Root Directory"
       }
     ],
     "configuration": {
       "title": "Meson build configuration",
       "properties": {
+        "mesonbuild.selectRootDir": {
+          "type": "boolean",
+          "default": true,
+          "description": "Ask to select a Meson project root directory when more than one project is detected."
+        },
         "mesonbuild.configureOnOpen": {
           "type": [
             "boolean",
@@ -437,6 +446,10 @@
         {
           "command": "mesonbuild.restartLanguageServer",
           "when": "mesonbuild.hasProject"
+        },
+        {
+          "command": "mesonbuild.selectRootDir",
+          "when": "mesonbuild.hasMultipleProjects"
         }
       ]
     },

--- a/src/dialogs.ts
+++ b/src/dialogs.ts
@@ -96,9 +96,13 @@ export async function askSelectRootDir(): Promise<boolean> {
 }
 
 export async function selectRootDir(rootDirs: string[]): Promise<string | undefined> {
-  // TODO: What label to use when there is more than one workspace?
-  const root = vscode.workspace.rootPath ?? "";
-  const items = rootDirs.map((file, index) => ({ index: index, label: path.relative(root, file) }));
+  // Append meson.build to directories otherwise asRelativePath() returns the
+  // absolute path when the path is the root of a workspace. Even if we fix that,
+  // it would leaves us with an empty string which is not better.
+  const items = rootDirs.map((file, index) => ({
+    index: index,
+    label: vscode.workspace.asRelativePath(path.join(file, "meson.build")),
+  }));
   items.sort((a, b) => {
     const aComponents = a.label.split(path.sep).length;
     const bComponents = b.label.split(path.sep).length;

--- a/src/dialogs.ts
+++ b/src/dialogs.ts
@@ -1,0 +1,66 @@
+import * as vscode from "vscode";
+import { extensionConfiguration, extensionConfigurationSet } from "./utils";
+import { SettingsKey } from "./types";
+
+export async function askConfigureOnOpen(): Promise<boolean> {
+  const configureOnOpen = extensionConfiguration(SettingsKey.configureOnOpen);
+
+  if (typeof configureOnOpen === "boolean") return configureOnOpen;
+
+  enum Options {
+    yes = "Yes",
+    always = "Always",
+    no = "No",
+    never = "Never",
+  }
+
+  const response = await vscode.window.showInformationMessage(
+    "Meson project detected in this workspace but does not seems to be configured. Would you like VS Code to configure it?",
+    ...Object.values(Options),
+  );
+
+  switch (response) {
+    case Options.no:
+      return false;
+    case Options.never:
+      extensionConfigurationSet(SettingsKey.configureOnOpen, false, vscode.ConfigurationTarget.Workspace);
+      return false;
+    case Options.yes:
+      return true;
+    case Options.always:
+      extensionConfigurationSet(SettingsKey.configureOnOpen, true, vscode.ConfigurationTarget.Workspace);
+      return true;
+  }
+
+  return false;
+}
+
+export async function askShouldDownloadLanguageServer(): Promise<boolean> {
+  const downloadLanguageServer = extensionConfiguration(SettingsKey.downloadLanguageServer);
+
+  if (typeof downloadLanguageServer === "boolean") return downloadLanguageServer;
+
+  enum Options {
+    yes = "Yes",
+    no = "Not this time",
+    never = "Never",
+  }
+
+  const response = await vscode.window.showInformationMessage(
+    "Should the extension try to download the language server?",
+    ...Object.values(Options),
+  );
+
+  switch (response) {
+    case Options.yes:
+      extensionConfigurationSet(SettingsKey.downloadLanguageServer, true, vscode.ConfigurationTarget.Global);
+      return true;
+    case Options.never:
+      extensionConfigurationSet(SettingsKey.downloadLanguageServer, false, vscode.ConfigurationTarget.Global);
+      return false;
+    case Options.no:
+      return false;
+  }
+
+  return false;
+}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -51,7 +51,7 @@ export async function activate(ctx: vscode.ExtensionContext) {
 
   ctx.subscriptions.push(
     vscode.commands.registerCommand("mesonbuild.selectRootDir", async () => {
-      let newRootDir = await selectRootDir(rootDirs);
+      let newRootDir = await selectRootDir(await mesonRootDirs());
       if (newRootDir && newRootDir != rootDir) {
         await workspaceState.update("mesonbuild.sourceDir", newRootDir);
         vscode.commands.executeCommand("workbench.action.reloadWindow");

--- a/src/types.ts
+++ b/src/types.ts
@@ -32,6 +32,7 @@ export interface ExtensionConfiguration {
   languageServer: LanguageServer;
   languageServerPath: string;
   downloadLanguageServer: boolean | "ask";
+  selectRootDir: boolean;
 }
 
 export interface TaskQuickPickItem extends vscode.QuickPickItem {
@@ -129,4 +130,5 @@ export enum SettingsKey {
   downloadLanguageServer = "downloadLanguageServer",
   languageServer = "languageServer",
   configureOnOpen = "configureOnOpen",
+  selectRootDir = "selectRootDir",
 }


### PR DESCRIPTION
There were many issues, including:
- The most common case is to have a meson.build at the root of the workspace. In that case we should not ask user anything.
- Only the first meson.build in a subdir tree is useful, others are unlikely to be projects.
- We need a way to never ask again to select a meson file, especially important when opening meson project itself which does not have a meson.build at the root, but many projects in test cases.
- If the user cancels selection, the meson extension cannot do anything and should be hidden.
- Selecting a meson file and configuring the project are 2 distinct questions. The user may want to select a file but not let vscode configure it. It is common to configure from an external terminal.