### PR TITLE
Look up relative paths to the language server in `PATH` first

### DIFF
--- a/src/lsp/index.ts
+++ b/src/lsp/index.ts
@@ -148,8 +148,15 @@ export abstract class LanguageServerClient {
 
   static resolveLanguageServerPath(server: LanguageServer, context: vscode.ExtensionContext): vscode.Uri | null {
     const config = vscode.workspace.getConfiguration("mesonbuild");
-    if (config["languageServerPath"] !== null && config["languageServerPath"] != "")
-      return vscode.Uri.from({ scheme: "file", path: config["languageServerPath"] });
+
+    const configLanguageServerPath = config["languageServerPath"];
+    if (configLanguageServerPath !== null && configLanguageServerPath != "") {
+      if (!path.isAbsolute(configLanguageServerPath)) {
+        const binary = which.sync(configLanguageServerPath, { nothrow: true });
+        if (binary !== null) return vscode.Uri.from({ scheme: "file", path: binary });
+      }
+      return vscode.Uri.from({ scheme: "file", path: configLanguageServerPath });
+    }
 
     const cached = LanguageServerClient.cachedLanguageServer(server, context);
     if (cached !== null) return cached;


### PR DESCRIPTION
In the case the custom path to the language server is relative, look it up in `PATH` first. Useful if the name of the language server is `swift-mesonlsp` instead of `Swift-MesonLSP`.