### PR TITLE
Use shell mode for executing commands

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -25,7 +25,12 @@ export async function exec(command: string, args: string[], options: cp.ExecFile
   });
 }
 
-export async function execFeed(command: string, args: string[], options: cp.ExecFileOptions = { shell: true }, stdin: string) {
+export async function execFeed(
+  command: string,
+  args: string[],
+  options: cp.ExecFileOptions = { shell: true },
+  stdin: string,
+) {
   return new Promise<ExecResult>((resolve) => {
     const p = cp.execFile(command, args, options, (error, stdout, stderr) => {
       resolve({ stdout, stderr, error: error ? error : undefined });

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -13,7 +13,7 @@ export interface ExecResult {
   error?: cp.ExecFileException;
 }
 
-export async function exec(command: string, args: string[], options: cp.ExecOptions = {}) {
+export async function exec(command: string, args: string[], options: cp.ExecFileOptions = { shell: true }) {
   return new Promise<ExecResult>((resolve, reject) => {
     cp.execFile(command, args, options, (error, stdout, stderr) => {
       if (error) {
@@ -25,7 +25,7 @@ export async function exec(command: string, args: string[], options: cp.ExecOpti
   });
 }
 
-export async function execFeed(command: string, args: string[], options: cp.ExecOptions = {}, stdin: string) {
+export async function execFeed(command: string, args: string[], options: cp.ExecFileOptions = { shell: true }, stdin: string) {
   return new Promise<ExecResult>((resolve) => {
     const p = cp.execFile(command, args, options, (error, stdout, stderr) => {
       resolve({ stdout, stderr, error: error ? error : undefined });


### PR DESCRIPTION
In Windows when running the plugin with the MSYS2 Meson package, the plugin throws the error "Meson version doesn't match expected output:". After some investigation I found that the response from `execFile` was returning: `error: null`, `stdout: ""` and `stderr: "1.3.0"`. I was unable to replicate this behavior in a shell, so I updated `execFile` to use "shell" mode by default, which solves the issue.

This seems to be specific to the MSYS2 package of meson, since using the pip version runs fine. However, since this is such a simple change that should not affect functionality, I thought I'd submit it.