### PR TITLE
Make sure rust-analyser uses rust-project.json Meson generates

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -202,3 +202,12 @@ export async function rootMesonFiles(): Promise<vscode.Uri[]> {
 
   return rootFiles;
 }
+
+export function whenFileExists(ctx: vscode.ExtensionContext, file: string, listener: () => void) {
+  const watcher = vscode.workspace.createFileSystemWatcher(file, false, true, true);
+  watcher.onDidCreate(listener);
+  ctx.subscriptions.push(watcher);
+  if (fs.existsSync(file)) {
+    listener();
+  }
+}


### PR DESCRIPTION
This is very similar case than compile_commands.json, Meson generates a file in builddir that some extensions should be using. It makes static analysers work out of the box instead of requiring user to configure paths themself.

We only need to watch for file creation, it was previously wrongly watching for file changes for legacy reasons (we used to patch compile_commands.json).
