### PR TITLE
utils: fix symlink handling in mesonRootDirs

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -198,11 +198,11 @@ export async function mesonRootDirs(): Promise<string[]> {
     let hasMesonFile: boolean = false;
     let subdirs: vscode.Uri[] = [];
     for (const [name, type] of await vscode.workspace.fs.readDirectory(d)) {
-      if ((type === vscode.FileType.File || type === vscode.FileType.SymbolicLink) && name == "meson.build") {
+      if (type & vscode.FileType.File && name == "meson.build") {
         rootDirs.push(d.fsPath);
         hasMesonFile = true;
         break;
-      } else if (type === vscode.FileType.Directory) {
+      } else if (type & vscode.FileType.Directory) {
         subdirs.push(vscode.Uri.joinPath(d, name));
       }
     }


### PR DESCRIPTION
Bitwise check for File or Directory type to properly handle symlinks of both

* Follow up for: #208

Testing:
- symlinked root `meson.build` gets picked up automatically
- symlinked directory with `meson.build` appears in the `Select configuration to use` prompt if there's no root `meson.build`
- regular files and directories still work
- (symlinked) directory named `meson.build` doesn't get picked up as root configuration

Based on [this sample](https://github.com/microsoft/vscode-extension-samples/blob/main/nodefs-provider-sample/src/extension.ts#L267).