### PR TITLE
Environment variables for setup and test tasks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,10 @@
 
 ## next
 
-- Add `mesonbuild.configureEnvironment` to set additional environment
-  variables during setup
+- Add `mesonbuild.configureEnvironment` to set additional environment variables
+  during setup
+- Add `mesonbuild.testEnvironment` to set additional environment variables while
+  running tests
 
 ## 1.21.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## next
 
+- Add `mesonbuild.configureEnvironment` to set additional environment
+  variables during setup
+
 ## 1.21.0
 
 - Remove `mesonbuild.setupRustAnalyzer` and `mesonbuild.setupCppTools` in favor

--- a/package.json
+++ b/package.json
@@ -129,6 +129,14 @@
           "default": [],
           "description": "Specify the list of options used for Meson setup."
         },
+        "mesonbuild.configureEnvironment": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "default": {},
+          "description": "Specify the list of additional environment variables used for setup."
+        },
         "mesonbuild.setupOptions": {
           "type": "array",
           "default": [],

--- a/package.json
+++ b/package.json
@@ -122,12 +122,12 @@
         "mesonbuild.buildFolder": {
           "type": "string",
           "default": "builddir",
-          "description": "Specify in which folder Meson build configure and build the project. Changing this value will reload the VS Code window."
+          "description": "Specify in which folder Meson configures and builds the project. Changing this value will reload the VS Code window."
         },
         "mesonbuild.configureOptions": {
           "type": "array",
           "default": [],
-          "description": "Specify the list of options used for Meson setup."
+          "description": "Specify the list of options used for setup."
         },
         "mesonbuild.configureEnvironment": {
           "type": "object",
@@ -140,7 +140,7 @@
         "mesonbuild.setupOptions": {
           "type": "array",
           "default": [],
-          "description": "Specify the list of options used for Meson setup. Can be used to specify a cross file (use --cross-file=FILE).",
+          "description": "Specify the list of options used for setup. Can be used to specify a cross file (use --cross-file=FILE).",
           "deprecationMessage": "--cross-file and --native-file should be in configureOptions too."
         },
         "mesonbuild.testOptions": {

--- a/package.json
+++ b/package.json
@@ -148,6 +148,14 @@
           "default": [],
           "description": "Specify the list of options used for running tests."
         },
+        "mesonbuild.testEnvironment": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "default": {},
+          "description": "Specify the list of additional environment variables used for running tests."
+        },
         "mesonbuild.benchmarkOptions": {
           "type": "array",
           "default": [

--- a/src/introspection.ts
+++ b/src/introspection.ts
@@ -9,7 +9,7 @@ async function introspectMeson<T>(buildDir: string, filename: string, introspect
     return parsed;
   }
 
-  const { stdout } = await exec(extensionConfiguration("mesonPath"), ["introspect", introspectSwitch], {
+  const { stdout } = await exec(extensionConfiguration("mesonPath"), ["introspect", introspectSwitch], undefined, {
     cwd: buildDir,
   });
 

--- a/src/tasks.ts
+++ b/src/tasks.ts
@@ -58,11 +58,13 @@ function createReconfigureTask(meson: string, buildDir: string, sourceDir: strin
   const setupOpts = extensionConfiguration("setupOptions");
   const reconfigureOpts = checkMesonIsConfigured(buildDir) ? ["--reconfigure"] : [];
   const args = ["setup", ...reconfigureOpts, ...configureOpts, ...setupOpts, buildDir, sourceDir];
+  const env = extensionConfiguration("configureEnvironment");
+  const options = env ? { env } : {};
   return new vscode.Task(
     { type: "meson", mode: "reconfigure" },
     "Reconfigure",
     "Meson",
-    new vscode.ProcessExecution(meson, args),
+    new vscode.ProcessExecution(meson, args, options),
   );
 }
 

--- a/src/tasks.ts
+++ b/src/tasks.ts
@@ -82,7 +82,10 @@ export async function getMesonTasks(buildDir: string, sourceDir: string) {
       { type: "meson", mode: "test" },
       "Run all tests",
       "Meson",
-      new vscode.ProcessExecution(meson, ["test", ...extensionConfiguration("testOptions")], { cwd: buildDir }),
+      new vscode.ProcessExecution(meson, ["test", ...extensionConfiguration("testOptions")], {
+        cwd: buildDir,
+        env: extensionConfiguration("testEnvironment"),
+      }),
     );
     const defaultBenchmarkTask = new vscode.Task(
       { type: "meson", mode: "benchmark" },

--- a/src/tests.ts
+++ b/src/tests.ts
@@ -39,7 +39,11 @@ export async function testRunHandler(
     run.started(test);
     let starttime = Date.now();
     try {
-      await exec(extensionConfiguration("mesonPath"), ["test", "-C", buildDir, "--print-errorlog", test.id]);
+      await exec(
+        extensionConfiguration("mesonPath"),
+        ["test", "-C", buildDir, "--print-errorlog", test.id],
+        extensionConfiguration("testEnvironment"),
+      );
       let duration = Date.now() - starttime;
       run.passed(test, duration);
     } catch (e) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -17,6 +17,7 @@ export interface ExtensionConfiguration {
   configureEnvironment: { [key: string]: string };
   setupOptions: string[];
   testOptions: string[];
+  testEnvironment: { [key: string]: string };
   benchmarkOptions: string[];
   buildFolder: string;
   mesonPath: string;

--- a/src/types.ts
+++ b/src/types.ts
@@ -14,6 +14,7 @@ export type ModifiableExtension = "ms-vscode.cpptools" | "rust-lang.rust-analyze
 export interface ExtensionConfiguration {
   configureOnOpen: boolean | "ask";
   configureOptions: string[];
+  configureEnvironment: { [key: string]: string };
   setupOptions: string[];
   testOptions: string[];
   benchmarkOptions: string[];

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -15,7 +15,15 @@ export interface ExecResult {
   error?: cp.ExecFileException;
 }
 
-export async function exec(command: string, args: string[], options: cp.ExecFileOptions = { shell: true }) {
+export async function exec(
+  command: string,
+  args: string[],
+  extraEnv: { [key: string]: string } | undefined = undefined,
+  options: cp.ExecFileOptions = { shell: true },
+) {
+  if (extraEnv) {
+    options.env = { ...(options.env ?? process.env), ...extraEnv };
+  }
   return new Promise<ExecResult>((resolve, reject) => {
     cp.execFile(command, args, options, (error, stdout, stderr) => {
       if (error) {


### PR DESCRIPTION
This adds two options, `configureEnvironment` and `testEnvironment`, allowing users to set particular environment variables during `meson setup` and `meson test`.

Closes: #9