### PR TITLE
Run Task: Use DevEnv

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -146,8 +146,6 @@ export function isThenable<T>(x: vscode.ProviderResult<T>): x is Thenable<T> {
   return arrayIncludes(Object.getOwnPropertyNames(x), "then");
 }
 
-let _envDict: { [key: string]: string } | undefined = undefined;
-
 export async function genEnvFile(buildDir: string) {
   const envfile = path.join(buildDir, "meson-vscode.env");
   try {
@@ -164,25 +162,6 @@ export async function genEnvFile(buildDir: string) {
     // Ignore errors, Meson could be too old to support --dump-format.
     return;
   }
-
-  // Load into a dict because vscode.ProcessExecution() does not support envFile.
-  _envDict = {};
-  const data = await fs.promises.readFile(envfile);
-  for (const i of data
-    .toString()
-    .split(/\r?\n/)
-    .filter((i) => i)) {
-    // Poor man's i.split("=", 1), JS won't return part after first equal sign.
-    // Value is quoted, remove first and last " char and also possible \r ending.
-    const index = i.indexOf("=");
-    const key = i.substring(0, index);
-    const value = i.slice(index + 2, -1);
-    _envDict[key] = value;
-  }
-}
-
-export function getEnvDict() {
-  return _envDict;
 }
 
 // meson setup --reconfigure is needed if and only if coredata.dat exists.


### PR DESCRIPTION
Run Task fails on Windows occasionally due to error 87 in creating process, this can be avoided, and manually entering env can be avoided by instead running the executable via meson's devenv