### PR TITLE
Fix tests with spaces in their names not executing when ran from the testing ui

### DIFF
--- a/src/tests.ts
+++ b/src/tests.ts
@@ -41,7 +41,7 @@ export async function testRunHandler(
     try {
       await exec(
         extensionConfiguration("mesonPath"),
-        ["test", "-C", buildDir, "--print-errorlog", test.id],
+        ["test", "-C", buildDir, "--print-errorlog", `"${test.id}"`],
         extensionConfiguration("testEnvironment"),
       );
       let duration = Date.now() - starttime;


### PR DESCRIPTION
Previously running a test which contained a space in its name, ie `command line parsing` would result in the test runner printing 
```
ERROR: *:command test name does not match any test
```
This encloses the test name in quotes so its parsed correctly on the command line.