### PR TITLE
Limit the depth of the meson.build search

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,9 @@
     "Programming Languages"
   ],
   "activationEvents": [
-    "workspaceContains:**/meson.build",
+    "workspaceContains:meson.build",
+    "workspaceContains:*/meson.build",
+    "workspaceContains:*/*/meson.build",
     "onDebugDynamicConfigurations",
     "onDebugDynamicConfigurations:cppdbg",
     "onDebugDynamicConfigurations:lldb"


### PR DESCRIPTION
Searching the entire workspace can be very costly, especially if the workspace is on a network drive. This change makes the extension assume that meson.build is located either in the workspace's root or in any directory two levels down from the root.

Potentially fixes #234.