### PR TITLE
Pass environment to the testing debugger

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -134,6 +134,14 @@ export interface Test {
   depends: string[];
 }
 
+interface StdDebugEnvironmentConfiguration {
+  env: { [key: string]: string };
+}
+interface CppDebugEnvironmentConfiguration {
+  environment: { name: string; value: string }[];
+}
+export type DebugEnvironmentConfiguration = StdDebugEnvironmentConfiguration | CppDebugEnvironmentConfiguration;
+
 export type Targets = Target[];
 export type BuildOptions = BuildOption<any>[];
 export type Dependencies = Dependency[];


### PR DESCRIPTION
The C++ debugger requires "environment" key in the format
[ { "name": "config", "value": "Debug" } ]
https://code.visualstudio.com/docs/cpp/launch-json-reference

Note: I think [Javascript](https://code.visualstudio.com/docs/editor/debugging) uses 'env'. [Python](https://code.visualstudio.com/docs/python/debugging#_env) uses 'env'. Annoying. This patch doesn't account for Javascript or Python. Not sure if that is a problem.

Fixes #240