### PR TITLE
Add meson as formatter

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,8 +28,6 @@ the [Material Design Icons](https://materialdesignicons.com/) project.
   introspection files:
   `"C_Cpp.default.configurationProvider": "mesonbuild.mesonbuild"`
 
-\* - requires an installation of [muon](https://muon.build).
-
 ## New Extension ID
 
 If you come from a previous installation, please make sure you are on the
@@ -41,4 +39,4 @@ extension on the store, and only that one is released from this repository.
     [mesonlsp](https://github.com/JCWasmx86/mesonlsp) or
     [muon](https://muon.build).
 
-[^1]: Requires an installation of muon.
+[^1]: Requires an installation of muon or meson >= 1.5.0

--- a/package.json
+++ b/package.json
@@ -194,7 +194,8 @@
           "type": "string",
           "default": "muon",
           "enum": [
-            "muon"
+            "muon",
+            "meson"
           ],
           "description": "Select which formatting provider to use"
         },
@@ -202,6 +203,11 @@
           "type": "string",
           "default": null,
           "description": "Path to muon formatter config.ini"
+        },
+        "mesonbuild.formatting.mesonConfig": {
+          "type": "string",
+          "default": null,
+          "description": "Path to meson format config 'meson.format'"
         },
         "mesonbuild.debugOptions": {
           "type": "object",

--- a/src/formatters.ts
+++ b/src/formatters.ts
@@ -1,7 +1,8 @@
 import * as vscode from "vscode";
 import { extensionConfiguration, getOutputChannel } from "./utils";
-import { ToolCheckFunc, Tool } from "./types";
+import { ToolCheckFunc, Tool, type FormattingProvider } from "./types";
 import * as muon from "./tools/muon";
+import * as meson from "./tools/meson";
 
 type FormatterFunc = (tool: Tool, root: string, document: vscode.TextDocument) => Promise<vscode.TextEdit[]>;
 
@@ -10,10 +11,14 @@ type FormatterDefinition = {
   check: ToolCheckFunc;
 };
 
-const formatters: Record<string, FormatterDefinition> = {
+const formatters: Record<FormattingProvider, FormatterDefinition> = {
   muon: {
     format: muon.format,
     check: muon.check,
+  },
+  meson: {
+    format: meson.format,
+    check: meson.check,
   },
 };
 

--- a/src/introspection.ts
+++ b/src/introspection.ts
@@ -1,6 +1,6 @@
 import * as path from "path";
 import { exec, extensionConfiguration, parseJSONFileIfExists, getOutputChannel } from "./utils";
-import { Targets, Dependencies, BuildOptions, Tests, ProjectInfo, Compilers } from "./types";
+import { Targets, Dependencies, BuildOptions, Tests, ProjectInfo, Compilers, type Version } from "./types";
 
 export function getIntrospectionFile(buildDir: string, filename: string) {
   return path.join(buildDir, path.join("meson-info", filename));
@@ -56,12 +56,12 @@ export async function getMesonBenchmarks(buildDir: string) {
   return introspectMeson<Tests>(buildDir, "intro-benchmarks.json", "--benchmarks");
 }
 
-export async function getMesonVersion(): Promise<[number, number, number]> {
+export async function getMesonVersion(): Promise<Version> {
   const MESON_VERSION_REGEX = /^(\d+)\.(\d+)\.(\d+)/g;
 
   const { stdout } = await exec(extensionConfiguration("mesonPath"), ["--version"]);
   const match = stdout.trim().match(MESON_VERSION_REGEX);
   if (match) {
-    return match.slice(1, 3).map((s) => Number.parseInt(s)) as [number, number, number];
+    return match.slice(1, 3).map((s) => Number.parseInt(s)) as Version;
   } else throw new Error("Meson version doesn't match expected output: " + stdout.trim());
 }

--- a/src/tools/meson.ts
+++ b/src/tools/meson.ts
@@ -12,10 +12,14 @@ export async function format(meson: Tool, root: string, document: vscode.TextDoc
   if (config_path) {
     args.push("-c", config_path);
   }
+
+  //TODO: this doesn't work, we have file a bug report upstream, that "-" (or any other notation for stdin) should be supported
+  // or use hacky way and use "/dev/stdin" or "/dev/fd/0" as file
   args.push("-");
 
   const { stdout, stderr, error } = await execFeed(meson.path, args, { cwd: root }, originalDocumentText);
   if (error) {
+    //TODO: file a bug report, meson prints error on stdout :(
     getOutputChannel().appendLine(`Failed to format document with meson: ${stderr}`);
     getOutputChannel().show(true);
     return [];

--- a/src/tools/meson.ts
+++ b/src/tools/meson.ts
@@ -1,0 +1,51 @@
+import * as vscode from "vscode";
+import { execFeed, extensionConfiguration, getOutputChannel, mesonProgram, versionCompare } from "../utils";
+import { Tool } from "../types";
+import { getMesonVersion } from "../introspection";
+
+export async function format(meson: Tool, root: string, document: vscode.TextDocument): Promise<vscode.TextEdit[]> {
+  const originalDocumentText = document.getText();
+
+  let args = ["format"];
+
+  const config_path = extensionConfiguration("formatting").mesonConfig;
+  if (config_path) {
+    args.push("-c", config_path);
+  }
+  args.push("-");
+
+  const { stdout, stderr, error } = await execFeed(meson.path, args, { cwd: root }, originalDocumentText);
+  if (error) {
+    getOutputChannel().appendLine(`Failed to format document with meson: ${stderr}`);
+    getOutputChannel().show(true);
+    return [];
+  }
+
+  const documentRange = new vscode.Range(
+    document.lineAt(0).range.start,
+    document.lineAt(document.lineCount - 1).rangeIncludingLineBreak.end,
+  );
+
+  return [new vscode.TextEdit(documentRange, stdout)];
+}
+
+export async function check(): Promise<{ tool?: Tool; error?: string }> {
+  const meson_path = mesonProgram();
+
+  let mesonVersion;
+  try {
+    mesonVersion = await getMesonVersion();
+  } catch (e) {
+    const error = e as Error;
+    console.log(error);
+    return { error: error.message };
+  }
+
+  // meson format was introduced in 1.5.0
+  // see https://mesonbuild.com/Commands.html#format
+  if (versionCompare(mesonVersion, [1, 5, 0]) >= 0) {
+    return { error: `Meson support formatting only since version 1,.5.0, but you ave version ${mesonVersion}` };
+  }
+
+  return { tool: { path: meson_path, version: mesonVersion } };
+}

--- a/src/tools/muon.ts
+++ b/src/tools/muon.ts
@@ -1,6 +1,6 @@
 import * as vscode from "vscode";
 import { ExecResult, exec, execFeed, extensionConfiguration, getOutputChannel } from "../utils";
-import { Tool } from "../types";
+import { Tool, type Version } from "../types";
 
 export async function lint(muon: Tool, root: string, document: vscode.TextDocument): Promise<vscode.Diagnostic[]> {
   const { stderr } = await execFeed(
@@ -98,7 +98,7 @@ export async function check(): Promise<{ tool?: Tool; error?: string }> {
       }
 
       return Number.parseInt(s);
-    }) as [number, number, number];
+    }) as Version;
 
   return { tool: { path: muon_path, version: ver } };
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,7 +1,8 @@
 import * as vscode from "vscode";
 
 type Dict<T> = { [x: string]: T };
-export type Tool = { path: string; version: [number, number, number] };
+export type Version = [number, number, number];
+export type Tool = { path: string; version: Version };
 export type ToolCheckFunc = () => Promise<{ tool?: Tool; error?: string }>;
 
 export type LinterConfiguration = {
@@ -10,6 +11,8 @@ export type LinterConfiguration = {
 
 export type LanguageServer = "Swift-MesonLSP" | "mesonlsp" | null;
 export type ModifiableExtension = "ms-vscode.cpptools" | "rust-lang.rust-analyzer";
+
+export type FormattingProvider = "muon" | "meson";
 
 export interface ExtensionConfiguration {
   configureOnOpen: boolean | "ask";
@@ -28,8 +31,9 @@ export interface ExtensionConfiguration {
   };
   formatting: {
     enabled: boolean;
-    provider: "muon";
+    provider: FormattingProvider;
     muonConfig: string | null;
+    mesonConfig: string | null;
   };
   debugOptions: object;
   languageServer: LanguageServer;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -5,7 +5,7 @@ import * as vscode from "vscode";
 import * as which from "which";
 
 import { createHash, BinaryLike } from "crypto";
-import { ExtensionConfiguration, Target, SettingsKey, ModifiableExtension } from "./types";
+import { ExtensionConfiguration, Target, SettingsKey, ModifiableExtension, type Version } from "./types";
 import { getMesonBuildOptions } from "./introspection";
 import { extensionPath, workspaceState } from "./extension";
 
@@ -208,4 +208,23 @@ export function whenFileExists(ctx: vscode.ExtensionContext, file: string, liste
 
 export function mesonProgram(): string {
   return which.sync(extensionConfiguration("mesonPath"));
+}
+
+/** This compares two versions
+ *  - if the first one is bigger, a value > 0 is returned
+ *  - if they are the same, 0 is returned
+ *  - if the first one is smaller, a value < 0 is returned
+ * @param version1
+ * @param version2
+ */
+export function versionCompare([major1, minor1, patch1]: Version, [major2, minor2, patch2]: Version): number {
+  if (major1 !== major2) {
+    return major1 - major2;
+  }
+
+  if (minor1 !== minor2) {
+    return minor1 - minor2;
+  }
+
+  return patch1 - patch2;
 }


### PR DESCRIPTION
Add meson as formatter

Since meson 1.5.0 meson has a format subcommand, see [here](https://mesonbuild.com/Commands.html#format)


This is still WIP, as the formatter doesn't accept stdin via "-" atm.