### PR TITLE
General improvments

### DIFF
--- a/src/formatters.ts
+++ b/src/formatters.ts
@@ -27,16 +27,16 @@ async function reloadFormatters(sourceRoot: string, context: vscode.ExtensionCon
   const name = extensionConfiguration("formatting").provider;
   const props = formatters[name];
 
-  const { tool, error } = await props.check();
-  if (error) {
-    getOutputChannel().appendLine(`Failed to enable formatter ${name}: ${error}`);
+  const checkResult = await props.check();
+  if (checkResult.isError()) {
+    getOutputChannel().appendLine(`Failed to enable formatter ${name}: ${checkResult.error}`);
     getOutputChannel().show(true);
     return disposables;
   }
 
   const sub = vscode.languages.registerDocumentFormattingEditProvider("meson", {
     async provideDocumentFormattingEdits(document: vscode.TextDocument): Promise<vscode.TextEdit[]> {
-      return await props.format(tool!, sourceRoot, document);
+      return await props.format(checkResult.tool, sourceRoot, document);
     },
   });
 

--- a/src/introspection.ts
+++ b/src/introspection.ts
@@ -57,11 +57,11 @@ export async function getMesonBenchmarks(buildDir: string) {
 }
 
 export async function getMesonVersion(): Promise<[number, number, number]> {
-  const MESON_VERSION_REGEX = /^(\d+)\.(\d+)\.(\d+)/g;
+  const MESON_VERSION_REGEX = /^(\d+)\.(\d+)\.(\d+)/;
 
   const { stdout } = await exec(extensionConfiguration("mesonPath"), ["--version"]);
   const match = stdout.trim().match(MESON_VERSION_REGEX);
-  if (match) {
-    return match.slice(1, 3).map((s) => Number.parseInt(s)) as [number, number, number];
+  if (match && match.length >= 4) {
+    return match.slice(1, 4).map((s) => Number.parseInt(s)) as [number, number, number];
   } else throw new Error("Meson version doesn't match expected output: " + stdout.trim());
 }

--- a/src/linters.ts
+++ b/src/linters.ts
@@ -38,14 +38,14 @@ async function reloadLinters(
     }
 
     const props = linters[name];
-    const { tool, error } = await props.check();
-    if (error) {
-      getOutputChannel().appendLine(`Failed to enable linter ${name}: ${error}`);
+    const checkResult = await props.check();
+    if (checkResult.isError()) {
+      getOutputChannel().appendLine(`Failed to enable linter ${name}: ${checkResult.error}`);
       getOutputChannel().show(true);
       continue;
     }
 
-    const linter = async (document: vscode.TextDocument) => await props.lint(tool!, sourceRoot, document);
+    const linter = async (document: vscode.TextDocument) => await props.lint(checkResult.tool, sourceRoot, document);
     enabledLinters.push(linter);
   }
 

--- a/src/tests.ts
+++ b/src/tests.ts
@@ -88,7 +88,7 @@ export async function testDebugHandler(
     relevantTests.some((test) => test.depends.some((dep) => dep == target.id)),
   );
 
-  var args = ["compile", "-C", buildDir];
+  let args = ["compile", "-C", buildDir];
   requiredTargets.forEach((target) => {
     args.push(target.name);
   });

--- a/src/tools/muon.ts
+++ b/src/tools/muon.ts
@@ -1,6 +1,7 @@
 import * as vscode from "vscode";
 import { ExecResult, exec, execFeed, extensionConfiguration, getOutputChannel } from "../utils";
-import { Tool } from "../types";
+import { Tool, ToolCheckResult } from "../types";
+import { Version, type VersionArray } from "../version";
 
 export async function lint(muon: Tool, root: string, document: vscode.TextDocument): Promise<vscode.Diagnostic[]> {
   const { stdout, stderr } = await execFeed(
@@ -10,8 +11,9 @@ export async function lint(muon: Tool, root: string, document: vscode.TextDocume
     document.getText(),
   );
 
-  var out;
-  if (muon.version[0] == 0 && muon.version[1] <= 3) {
+  let out: string;
+  // if (muonVersion < 0.4.0)
+  if (muon.version.compare([0, 4, 0]) < 0) {
     out = stderr;
   } else {
     out = stdout;
@@ -54,7 +56,8 @@ export async function format(muon: Tool, root: string, document: vscode.TextDocu
 
   let args = ["fmt"];
 
-  if (muon.version[0] == 0 && muon.version[1] == 0) {
+  // if (muonVersion < 0.1.0)
+  if (muon.version.compare([0, 1, 0]) < 0) {
     args = ["fmt_unstable"];
   }
 
@@ -79,7 +82,7 @@ export async function format(muon: Tool, root: string, document: vscode.TextDocu
   return [new vscode.TextEdit(documentRange, stdout)];
 }
 
-export async function check(): Promise<{ tool?: Tool; error?: string }> {
+export async function check(): Promise<ToolCheckResult> {
   const muon_path = extensionConfiguration("muonPath");
   let stdout: string, stderr: string;
 
@@ -88,12 +91,12 @@ export async function check(): Promise<{ tool?: Tool; error?: string }> {
   } catch (e) {
     const { error, stdout, stderr } = e as ExecResult;
     console.log(error);
-    return { error: error!.message };
+    return ToolCheckResult.newError(error!.message);
   }
 
   const line1 = stdout.split("\n")[0].split(" ");
   if (line1.length !== 2) {
-    return { error: `Invalid version string: ${line1}` };
+    return ToolCheckResult.newError(`Invalid version string: ${line1}`);
   }
 
   const ver = line1[1]
@@ -105,7 +108,7 @@ export async function check(): Promise<{ tool?: Tool; error?: string }> {
       }
 
       return Number.parseInt(s);
-    }) as [number, number, number];
+    }) as VersionArray;
 
-  return { tool: { path: muon_path, version: ver } };
+  return ToolCheckResult.newTool({ path: muon_path, version: new Version(ver) });
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -5,7 +5,14 @@ import * as vscode from "vscode";
 import * as which from "which";
 
 import { createHash, BinaryLike } from "crypto";
-import { ExtensionConfiguration, Target, SettingsKey, ModifiableExtension } from "./types";
+import {
+  ExtensionConfiguration,
+  Target,
+  SettingsKey,
+  ModifiableExtension,
+  type ToolCheckResult,
+  type ToolCheckErrorResult,
+} from "./types";
 import { getMesonBuildOptions } from "./introspection";
 import { extensionPath, workspaceState } from "./extension";
 

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,0 +1,72 @@
+export type VersionArray = [number, number, number];
+
+const versionNames = ["major", "minor", "patch"] as const;
+
+export class Version {
+  constructor(private readonly version: VersionArray) {
+    const isValid = Version.isValidVersion(this.version);
+
+    if (isValid !== true) {
+      throw isValid;
+    }
+  }
+
+  /** This checks if any type is a valid version array at runtime
+   *
+   * @param version the version to check
+   */
+  private static isValidVersion(version: Version | any): true | Error {
+    if (!Array.isArray(version)) {
+      return new Error("Version object is not an Array");
+    }
+
+    if (version.length !== 3) {
+      return new Error(`Version array has ${version.length} entries, but expected 3`);
+    }
+
+    for (const index in version as VersionArray) {
+      const num = version[index];
+      if (!Number.isInteger(num)) {
+        const name = versionNames[index];
+        return new Error(`${name} version component is not a number: '${num}'`);
+      }
+    }
+
+    return true;
+  }
+
+  /** This compares two versions
+   *  - if the first one is bigger, a value > 0 is returned
+   *  - if they are the same, 0 is returned
+   *  - if the first one is smaller, a value < 0 is returned
+   * @param version1
+   * @param version2
+   */
+  private static compareImpl([major1, minor1, patch1]: VersionArray, [major2, minor2, patch2]: VersionArray): number {
+    if (major1 !== major2) {
+      return major1 - major2;
+    }
+
+    if (minor1 !== minor2) {
+      return minor1 - minor2;
+    }
+
+    return patch1 - patch2;
+  }
+
+  compareWithOther(otherVersion: Version): number {
+    return Version.compareImpl(this.version, otherVersion.version);
+  }
+
+  compare(otherVersion: VersionArray): number {
+    return Version.compareImpl(this.version, otherVersion);
+  }
+
+  private static versionToString([major, minor, patch]: VersionArray): string {
+    return `${major}.${minor}.${patch}`;
+  }
+
+  toString(): string {
+    return Version.versionToString(this.version);
+  }
+}


### PR DESCRIPTION
This adds some general improvements and three bug fixes, I saw when implementing #261 

Bugs:
- The meson version wasn't detected correctly, since the `g` flag was used in the regex for the version number, so the resulting `match` array was `["1.6.0"]` instead of `["1.6.0","1","6","0"]`
- The version comparison was done manually in https://github.com/mesonbuild/vscode-meson/pull/268/commits/5e9c9e961e8195dcc7276686775a2ae8e8e4abfe#diff-9a3b5396b880a25586663b03f9bda56906914991b7b43b493283eca3ccc74fc3R28 and there we only checked `version[1] < 50`, which only worked correctly before `1.0.0` (thsi never showed, since after this check we additionally check, if the returned filename is an array or not, so this only cleans this up)
- The slicing of the version for meson was done incorrectly, `["1.6.0","1","6","0"].slice(1,.3)` results in `["1","6"]` and not in three components

Improvements:
- add Version class, that handles:
   - comparison, so that we don't make obvious errors and so that it's much simpler
   - toString function, so that it can be easily printed
   - check at runtime, if the input is correct, this can help detect feature  errors easier, if e.g. muon changes it's version string, that we parse, so that we get a nice and early error (this also helped my find bug 3)
   
   
Most of these things I "need" for #261 or at least it makes the life much more easy, (I print versions in some places, comparison is an improvement, that benefits also existing code) 

Feel free to suggest any changes 😄 