### PR TITLE
feat: add more sophisticated formatter selection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## next
 
 - Add support for meson as formatter
+- Use meson as default formatter
+- Add auto select capability for formatting provider preference
 
 ## 1.26.0
 

--- a/package.json
+++ b/package.json
@@ -192,12 +192,13 @@
         },
         "mesonbuild.formatting.provider": {
           "type": "string",
-          "default": "muon",
+          "default": "auto",
           "enum": [
-            "muon",
-            "meson"
+            "auto",
+            "meson",
+            "muon"
           ],
-          "description": "Select which formatting provider to use"
+          "description": "Select which formatting provider to use. If set to 'auto', the best available one is picked"
         },
         "mesonbuild.formatting.muonConfig": {
           "type": "string",

--- a/src/types.ts
+++ b/src/types.ts
@@ -82,7 +82,7 @@ export interface ExtensionConfiguration {
   };
   formatting: {
     enabled: boolean;
-    provider: FormattingProvider;
+    provider: FormattingProvider | "auto";
     muonConfig: string | null;
     mesonConfig: string | null;
   };


### PR DESCRIPTION
- allow the formatting provider to be set as `auto`, this means, select the best available one
- add internal priority for formatting providers


This adds an algorithm, that searches for the best available formatter. This results in the following behavior:
- if `formatting.provider` is set to `auto` we try to find a formatter in the following order `["meson", "muon"`], if one of them is found in this order, that one is used

- if `formatting.provider` is set to a specific formatter, it only tries that one and fails, if it didn't find that one

fixes #274

Let me know, me if this solution is acceptable. The problem with the previous code is, that it wasn't really designed to handle multiple formatting providers that well.