### PR TITLE
add lldb-dap support

### DIFF
--- a/src/debug/index.ts
+++ b/src/debug/index.ts
@@ -9,6 +9,7 @@ export enum DebuggerType {
   cppvsdbg = "cppvsdbg",
   cppdbg = "cppdbg",
   lldb = "lldb",
+  lldbDAP = "lldb-dap",
 }
 
 enum MIMode {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -83,6 +83,10 @@ export async function activate(ctx: vscode.ExtensionContext) {
     providers.push(new MesonDebugConfigurationProvider(DebuggerType.lldb, buildDir));
   }
 
+  if (vscode.extensions.getExtension("llvm-vs-code-extensions.lldb-dap")) {
+    providers.push(new MesonDebugConfigurationProvider(DebuggerType.lldbDAP, buildDir));
+  }
+
   // Install cppdbg or cppvsdbg provider if C/C++ extension is installed
   if (vscode.extensions.getExtension("ms-vscode.cpptools")) {
     if (os.platform() === "win32") {

--- a/src/tests.ts
+++ b/src/tests.ts
@@ -104,13 +104,14 @@ export async function testDebugHandler(
   let debugType = null;
 
   const cppTools = vscode.extensions.getExtension("ms-vscode.cpptools");
-  if (cppTools && cppTools.isActive) {
+  const codelldb = vscode.extensions.getExtension("vadimcn.vscode-lldb");
+  const lldbDAP = vscode.extensions.getExtension("llvm-vs-code-extensions.lldb-dap");
+  if (cppTools) {
     debugType = "cppdbg";
-  } else {
-    const codelldb = vscode.extensions.getExtension("vadimcn.vscode-lldb");
-    if (codelldb && codelldb.isActive) {
-      debugType = "lldb";
-    }
+  } else if (codelldb) {
+    debugType = "lldb";
+  } else if (lldbDAP) {
+    debugType = "lldb-dap";
   }
 
   if (!debugType) {


### PR DESCRIPTION
`llvm-vs-code-extensions.lldb-dap` is the new official lldb extension. The API is largely the same

Also note that `Extension().isActive` has never been correct - it returns whether the extension has been started, not whether it is enabled in the current workspace. See https://stackoverflow.com/a/78703190